### PR TITLE
Search houl.config.js(on) if config option is not specified

### DIFF
--- a/lib/cli/build.js
+++ b/lib/cli/build.js
@@ -1,20 +1,23 @@
 'use strict'
 
+const assert = require('assert')
 const path = require('path')
 const vfs = require('vinyl-fs')
 const loadConfig = require('../config').loadConfig
+const findConfig = require('../config').findConfig
 const processTask = require('../process-task')
 
 exports.builder = {
   config: {
     alias: 'c',
-    demand: true,
     describe: 'Path to a houl config file'
   }
 }
 
 exports.handler = argv => {
-  const config = loadConfig(argv.config)
+  const configPath = argv.config || findConfig(process.cwd())
+  assert(configPath, 'Config file is not found')
+  const config = loadConfig(configPath)
 
   // TODO: Execute pre tasks
 

--- a/lib/cli/build.js
+++ b/lib/cli/build.js
@@ -2,7 +2,7 @@
 
 const path = require('path')
 const vfs = require('vinyl-fs')
-const loadConfig = require('../config')
+const loadConfig = require('../config').loadConfig
 const processTask = require('../process-task')
 
 exports.builder = {

--- a/lib/cli/dev.js
+++ b/lib/cli/dev.js
@@ -6,7 +6,7 @@ const fs = require('fs')
 const vfs = require('vinyl-fs')
 const chokidar = require('chokidar')
 const bs = require('browser-sync').create()
-const loadConfig = require('../config')
+const loadConfig = require('../config').loadConfig
 
 exports.builder = {
   config: {

--- a/lib/cli/dev.js
+++ b/lib/cli/dev.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const assert = require('assert')
 const path = require('path')
 const url = require('url')
 const fs = require('fs')
@@ -7,17 +8,19 @@ const vfs = require('vinyl-fs')
 const chokidar = require('chokidar')
 const bs = require('browser-sync').create()
 const loadConfig = require('../config').loadConfig
+const findConfig = require('../config').findConfig
 
 exports.builder = {
   config: {
     alias: 'c',
-    demand: true,
     describe: 'Path to a houl config file'
   }
 }
 
 exports.handler = argv => {
-  const config = loadConfig(argv.config)
+  const configPath = argv.config || findConfig(process.cwd())
+  assert(configPath, 'Config file is not found')
+  const config = loadConfig(configPath)
 
   bs.init({
     server: config.output,

--- a/lib/config.js
+++ b/lib/config.js
@@ -21,7 +21,7 @@ function loadConfig (configPath) {
 
   return new Config(config, tasks, options)
 }
-module.exports = loadConfig
+exports.loadConfig = loadConfig
 
 function loadConfigFile (configPath) {
   const ext = path.extname(configPath)

--- a/lib/config.js
+++ b/lib/config.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert')
 const path = require('path')
+const fs = require('fs')
 const Config = require('./models/config')
 const util = require('./util')
 
@@ -40,3 +41,25 @@ function resolvePresetPath (preset, base) {
   }
   return require.resolve(path.resolve(base, preset))
 }
+
+function findConfig (dirname, exists) {
+  exists = exists || fs.existsSync
+
+  const jsConfig = path.join(dirname, 'houl.config.js')
+  if (exists(jsConfig)) {
+    return jsConfig
+  }
+
+  const jsonConfig = path.join(dirname, 'houl.config.json')
+  if (exists(jsonConfig)) {
+    return jsonConfig
+  }
+
+  const parent = path.dirname(dirname)
+  if (parent === dirname) {
+    return null
+  }
+
+  return findConfig(parent, exists)
+}
+exports.findConfig = findConfig

--- a/test/specs/config.spec.js
+++ b/test/specs/config.spec.js
@@ -1,10 +1,10 @@
 'use strict'
 
 const path = require('path')
-const config = require('../../lib/config')
+const loadConfig = require('../../lib/config').loadConfig
 
 const read = pathname => {
-  return config(path.join('test/fixtures', pathname))
+  return loadConfig(path.join('test/fixtures', pathname))
 }
 
 describe('Config', () => {

--- a/test/specs/config.spec.js
+++ b/test/specs/config.spec.js
@@ -2,6 +2,7 @@
 
 const path = require('path')
 const loadConfig = require('../../lib/config').loadConfig
+const findConfig = require('../../lib/config').findConfig
 
 const read = pathname => {
   return loadConfig(path.join('test/fixtures', pathname))
@@ -19,5 +20,40 @@ describe('Config', () => {
   it('throws if try loading other file', () => {
     expect(() => read('test.coffee'))
       .toThrowError(/test\.coffee is non-supported file format/)
+  })
+
+  it('search config file', () => {
+    function exists (pathname) {
+      return '/path/houl.config.js' === pathname
+    }
+
+    expect(findConfig('/path/to/project', exists)).toBe('/path/houl.config.js')
+  })
+
+  it('also search json config file', () => {
+    function exists (pathname) {
+      return '/path/houl.config.json' === pathname
+    }
+
+    expect(findConfig('/path/to/project', exists)).toBe('/path/houl.config.json')
+  })
+
+  it('prefers js config', () => {
+    function exists (pathname) {
+      return [
+        '/path/to/houl.config.json',
+        '/path/to/houl.config.js'
+      ].indexOf(pathname) >= 0
+    }
+
+    expect(findConfig('/path/to/', exists)).toBe('/path/to/houl.config.js')
+  })
+
+  it('returns null if not found', () => {
+    function exists (pathname) {
+      return '/path/to/houl.config.json' === pathname
+    }
+
+    expect(findConfig('/path/other/project', exists)).toBe(null)
   })
 })


### PR DESCRIPTION
If the users omit the `--config` option, houl will search the `houl.config.js` or `houl.config.json` in current working dir and its all ancestors.