### PR TITLE
Allow to specify dev server port

### DIFF
--- a/lib/cli/dev.js
+++ b/lib/cli/dev.js
@@ -14,6 +14,7 @@ exports.builder = {
   port: {
     alias: 'p',
     describe: 'Port number of dev server',
+    default: 3000,
     number: true
   }
 }

--- a/lib/cli/dev.js
+++ b/lib/cli/dev.js
@@ -10,6 +10,11 @@ exports.builder = {
   config: {
     alias: 'c',
     describe: 'Path to a houl config file'
+  },
+  port: {
+    alias: 'p',
+    describe: 'Port number of dev server',
+    number: true
   }
 }
 
@@ -18,7 +23,11 @@ exports.handler = argv => {
   assert(configPath, 'Config file is not found')
   const config = loadConfig(configPath)
 
-  const bs = create(config)
+  assert(!Number.isNaN(argv.port), '--port should be a number')
+
+  const bs = create(config, {
+    port: argv.port
+  })
 
   chokidar.watch(config.input, { ignoreInitial: true, cwd: config.input })
     .on('change', pathname => {

--- a/lib/externals/browser-sync.js
+++ b/lib/externals/browser-sync.js
@@ -14,10 +14,10 @@ const defaultBsOptions = {
   notify: false
 }
 
-module.exports = (config) => {
+module.exports = (config, bsOptions) => {
   const bs = browserSync.create()
 
-  const bsOptions = util.clone(defaultBsOptions)
+  bsOptions = util.merge(defaultBsOptions, bsOptions)
 
   bsOptions.server = config.output
   injectMiddleware(bsOptions, createMiddleware(config))


### PR DESCRIPTION
This `--port` (shorthand `-p`) option allows us to specify dev server's port number.
If the non-number value is specified, the command throws an error and immediately exits.