### PR TITLE
Resolve dependency of watched files

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,4 +1,6 @@
 ---
   extends: eslint-config-ktsn
+  env:
+    es6: true
   parserOptions:
     ecmaVersion: 6

--- a/lib/cli/dev.js
+++ b/lib/cli/dev.js
@@ -1,9 +1,12 @@
 'use strict'
 
 const assert = require('assert')
+const path = require('path')
 const chokidar = require('chokidar')
+const progeny = require('progeny')
 const loadConfig = require('../config').loadConfig
 const findConfig = require('../config').findConfig
+const DepResolver = require('../dep-resolver').DepResolver
 const create = require('../externals/browser-sync')
 
 exports.builder = {
@@ -26,19 +29,37 @@ exports.handler = argv => {
 
   assert(!Number.isNaN(argv.port), '--port should be a number')
 
+  const resolver = new DepResolver((...args) => {
+    return progeny.Sync()(...args)
+  })
+
   const bs = create(config, {
     port: argv.port
-  })
+  }, resolver)
 
   chokidar.watch(config.input, { ignoreInitial: true, cwd: config.input })
     .on('change', pathname => {
-      const rule = config.findRuleByInput(pathname)
+      const fullPath = path.resolve(config.input, pathname)
 
-      if (!rule) {
-        bs.reload(pathname)
-        return
-      }
+      // Update deps
+      resolver.register(fullPath)
 
-      bs.reload(rule.getOutputPath(pathname))
+      // Reload for changed file
+      const target = resolveOutput(fullPath)
+
+      // Resolve depended files
+      const reloadFiles = [target, ...resolver.resolve(fullPath).map(resolveOutput)]
+
+      bs.reload(reloadFiles)
     })
+
+  function resolveOutput (inputName) {
+    const rule = config.findRuleByInput(inputName)
+
+    if (!rule) {
+      return inputName
+    } else {
+      return rule.getOutputPath(inputName)
+    }
+  }
 }

--- a/lib/dep-resolver.js
+++ b/lib/dep-resolver.js
@@ -1,0 +1,80 @@
+'use strict'
+
+class DepResolver {
+  constructor (resolveDeps) {
+    // `progeny` - (filePath, fileContent) => filePath[]
+    this.resolveDeps = resolveDeps
+
+    this.files = new Map()
+  }
+
+  register (fileName, content) {
+    const file = this._getFile(fileName)
+    const newOut = this.resolveDeps(fileName, content)
+
+    this._cleanUpOutDeps(file)
+    file.outDeps = newOut
+    this._registerOutDeps(file)
+
+    this._setFile(fileName, file)
+  }
+
+  resolve (fileName) {
+    const origin = this._getFile(fileName)
+    const footprints = new Set()
+    footprints.add(origin.fileName)
+
+    const resolveImpl = (acc, fileName) => {
+      const file = this._getFile(fileName)
+
+      // detect circlar deps
+      if (footprints.has(file.fileName)) {
+        return acc
+      }
+
+      footprints.add(file.fileName)
+
+      return file.inDeps
+        .reduce(resolveImpl, acc.concat([file.fileName]))
+    }
+
+    return origin.inDeps.reduce(resolveImpl, [])
+  }
+
+  _getFile (fileName) {
+    const file = this.files.get(fileName)
+
+    if (file) return file
+
+    const newFile = {
+      fileName,
+      outDeps: [],
+      inDeps: []
+    }
+    this._setFile(fileName, newFile)
+    return newFile
+  }
+
+  _setFile (fileName, file) {
+    this.files.set(fileName, file)
+  }
+
+  _registerOutDeps (file) {
+    file.outDeps.forEach(name => {
+      const dep = this._getFile(name)
+      dep.inDeps.push(file.fileName)
+      this._setFile(dep.fileName, dep)
+    })
+  }
+
+  _cleanUpOutDeps (file) {
+    file.outDeps.forEach(name => {
+      const dep = this._getFile(name)
+      dep.inDeps = dep.inDeps.filter(inDep => {
+        return inDep !== file.fileName
+      })
+      this._setFile(dep.fileName, dep)
+    })
+  }
+}
+exports.DepResolver = DepResolver

--- a/lib/externals/browser-sync.js
+++ b/lib/externals/browser-sync.js
@@ -14,13 +14,13 @@ const defaultBsOptions = {
   notify: false
 }
 
-module.exports = (config, bsOptions) => {
+module.exports = (config, bsOptions, depResolver) => {
   const bs = browserSync.create()
 
   bsOptions = util.merge(defaultBsOptions, bsOptions)
 
   bsOptions.server = config.output
-  injectMiddleware(bsOptions, createMiddleware(config))
+  injectMiddleware(bsOptions, createMiddleware(config, depResolver))
 
   bs.init(bsOptions)
 
@@ -41,7 +41,7 @@ function injectMiddleware (options, middleware) {
   options.middleware = [middleware]
 }
 
-function createMiddleware (config) {
+function createMiddleware (config, depResolver) {
   return (req, res, next) => {
     const outputPath = normalizePath(url.parse(req.url).pathname)
     const rule = config.findRuleByOutput(outputPath, inputPath => {
@@ -57,7 +57,12 @@ function createMiddleware (config) {
 
     if (config.isExclude(inputPath)) return next()
 
-    rule.task(vfs.src(inputPath))
+    const src = vfs.src(inputPath)
+      .on('data', file => {
+        depResolver.register(file.path, String(file.contents))
+      })
+
+    rule.task(src)
       .on('data', file => {
         res.setHeader('Content-Type', mime.lookup(outputPath))
         res.end(file.contents)

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "chokidar": "^1.6.1",
     "mime": "^1.3.4",
     "minimatch": "^3.0.3",
+    "progeny": "^0.11.0",
     "vinyl-fs": "^2.4.4",
     "yargs": "^6.6.0"
   }

--- a/test/specs/dep-resolver.spec.js
+++ b/test/specs/dep-resolver.spec.js
@@ -1,0 +1,85 @@
+'use strict'
+
+const DepResolver = require('../../lib/dep-resolver').DepResolver
+
+describe('DepResolver', () => {
+  it('registers dependent files', () => {
+    const r = new DepResolver(() => ['/path/to/dep.js'])
+
+    // origin.js -depends-> dep.js
+    r.register('/path/to/origin.js', '')
+    expect(r.resolve('/path/to/dep.js')).toEqual([
+      '/path/to/origin.js'
+    ])
+
+    // origin.js  -depends--> dep.js
+    // another.js -depends-^
+    r.register('/path/to/another.js', '')
+    expect(r.resolve('/path/to/dep.js')).toEqual([
+      '/path/to/origin.js',
+      '/path/to/another.js'
+    ])
+  })
+
+  it('should not have redundant file paths', () => {
+    const r = new DepResolver(() => ['/path/to/dep.js'])
+
+    r.register('/path/to/origin.js', '')
+    r.register('/path/to/origin.js', '')
+
+    expect(r.resolve('/path/to/dep.js')).toEqual([
+      '/path/to/origin.js'
+    ])
+  })
+
+  it('resolves nested dependencies', () => {
+    const r = new DepResolver((_, content) => [content])
+
+    // a --> b -> d
+    // c -^
+    r.register('/a.js', '/b.js')
+    r.register('/c.js', '/b.js')
+    r.register('/b.js', '/d.js')
+
+    expect(r.resolve('/d.js')).toEqual([
+      '/b.js',
+      '/a.js',
+      '/c.js'
+    ])
+  })
+
+  it('handles circlar dependencies', () => {
+    const r = new DepResolver((_, content) => [content])
+
+    // a -> b -> c -> a -> ...
+    r.register('/a.js', '/b.js')
+    r.register('/b.js', '/c.js')
+    r.register('/c.js', '/a.js')
+
+    expect(r.resolve('/a.js')).toEqual([
+      '/c.js',
+      '/b.js'
+    ])
+  })
+
+  it('overwrites the dependencies of the file having the same name', () => {
+    const r = new DepResolver((_, content) => [content])
+
+    // foo --> test
+    // bar -^
+    r.register('/foo.js', '/test.js')
+    r.register('/bar.js', '/test.js')
+    expect(r.resolve('/test.js')).toEqual([
+      '/foo.js',
+      '/bar.js'
+    ])
+
+    r.register('/foo.js', '/test2.js')
+    expect(r.resolve('/test.js')).toEqual([
+      '/bar.js'
+    ])
+    expect(r.resolve('/test2.js')).toEqual([
+      '/foo.js'
+    ])
+  })
+})

--- a/test/specs/dep-resolver.spec.js
+++ b/test/specs/dep-resolver.spec.js
@@ -82,4 +82,9 @@ describe('DepResolver', () => {
       '/foo.js'
     ])
   })
+
+  it('returns empty array if target is not registered', () => {
+    const r = new DepResolver(() => ['noop'])
+    expect(r.resolve('/test.js')).toEqual([])
+  })
 })


### PR DESCRIPTION
This feature allows the auto reloading that reflected by updating dependent files. For example, when   file A depends on file B somehow, then the user browse A and update B, the browser will be reloaded.

More concrete example:

```scss
// A.scss
@import 'B'

.foo {
  color: $color;
}
```

```scss
// B.scss
$color: cyan;
```

In the above case, even if the user load only `A.scss` in her browser, the browser can be auto reloaded when she update `B.scss` because `A.scss` depends on `B.scss`.