### PR TITLE
Allow to set progeny options in rules

### DIFF
--- a/lib/cli/dev.js
+++ b/lib/cli/dev.js
@@ -8,6 +8,7 @@ const loadConfig = require('../config').loadConfig
 const findConfig = require('../config').findConfig
 const DepResolver = require('../dep-resolver').DepResolver
 const create = require('../externals/browser-sync')
+const util = require('../util')
 
 exports.builder = {
   config: {
@@ -29,8 +30,10 @@ exports.handler = argv => {
 
   assert(!Number.isNaN(argv.port), '--port should be a number')
 
-  const resolver = new DepResolver((...args) => {
-    return progeny.Sync()(...args)
+  const progenyOptions = util.mapValues(config.rules, rule => rule.progeny)
+  const resolver = new DepResolver((fileName, contents) => {
+    const ext = path.extname(fileName).slice(1)
+    return progeny.Sync(progenyOptions[ext])(fileName, contents)
   })
 
   const bs = create(config, {

--- a/lib/models/rule.js
+++ b/lib/models/rule.js
@@ -11,6 +11,7 @@ const emptyRule = new class EmptyRule {
     this.inputExt = null
     this.outputExt = null
     this.exclude = null
+    this.progeny = undefined
   }
 
   getInputPath (outputPath) {
@@ -34,6 +35,11 @@ module.exports = class Rule {
     this.inputExt = inputExt
     this.outputExt = rule.outputExt || this.inputExt
     this.exclude = rule.exclude
+
+    this.progeny = rule.progeny
+    if (this.progeny) {
+      this.progeny.extension = inputExt
+    }
   }
 
   getInputPath (outputPath) {

--- a/test/specs/models/rule.spec.js
+++ b/test/specs/models/rule.spec.js
@@ -7,7 +7,10 @@ describe('Rule model', () => {
     const r = new Rule({
       task: 'foo',
       outputExt: 'css',
-      exclude: '**/vendor/**'
+      exclude: '**/vendor/**',
+      progeny: {
+        rootPath: 'path/to/root'
+      }
     }, 'scss', {
       foo: () => 'foo',
       bar: () => 'bar'
@@ -18,6 +21,10 @@ describe('Rule model', () => {
     expect(r.inputExt).toBe('scss')
     expect(r.outputExt).toBe('css')
     expect(r.exclude).toBe('**/vendor/**')
+    expect(r.progeny).toEqual({
+      extension: 'scss',
+      rootPath: 'path/to/root'
+    })
   })
 
   it('deals with string format', () => {


### PR DESCRIPTION
This PR allows us to set progeny option in each item in `rules` field so that we can customize dependency resolution strategy of dev server.

See https://github.com/es128/progeny#configuration

```json
{
  "input": "src",
  "output": "dist",
  "rules": {
    "scss": {
      "task": "styles",
      "outputExt": "css",
      "progeny": {
        "rootPath": "/path/to/root"
      }
    }
  }
}
```