### PR TITLE
Redirect if trailing slash is omitted

### DIFF
--- a/lib/externals/browser-sync.js
+++ b/lib/externals/browser-sync.js
@@ -43,11 +43,14 @@ function injectMiddleware (options, middleware) {
 
 function createMiddleware (config, depResolver) {
   return (req, res, next) => {
-    const outputPath = normalizePath(url.parse(req.url).pathname)
+    const reqPath = url.parse(req.url).pathname
+    const outputPath = normalizePath(reqPath)
+
     const rule = config.findRuleByOutput(outputPath, inputPath => {
       return fs.existsSync(path.join(config.input, inputPath))
     })
 
+    // If any rules are not matched, leave it to browsersync
     if (!rule) return next()
 
     const inputPath = path.join(
@@ -55,7 +58,15 @@ function createMiddleware (config, depResolver) {
       rule.getInputPath(outputPath)
     )
 
+    // If Input file is excluded by config, leave it to browsersync
     if (config.isExclude(inputPath)) return next()
+
+    // If it is directory, redirect to path that added trailing slash
+    // There should not be not found error
+    // since it is already checked in previous process
+    if (fs.statSync(inputPath).isDirectory()) {
+      return redirect(res, reqPath + '/')
+    }
 
     const src = vfs.src(inputPath)
       .on('data', file => {
@@ -70,30 +81,19 @@ function createMiddleware (config, depResolver) {
   }
 }
 
-function normalizePath (pathname, base) {
-  let stat = null
-  try {
-    stat = fs.statSync(path.join(base, pathname))
-  } catch (err) { /* Do nothing */ }
+function redirect (res, pathname) {
+  res.statusCode = 301
+  res.setHeader('Location', pathname)
+  res.end()
+}
 
-  // If the given pathname is actually directory,
-  // add trailing slash to pathname
-  if (
-    !isDirectoryPath(pathname)
-    && stat && !stat.isDirectory()
-  ) {
-    pathname += '/'
-  }
-
-  // Fill `index.html` like ordinary static servers
+function normalizePath (pathname) {
   if (isDirectoryPath(pathname)) {
     pathname = path.join(pathname, 'index.html')
   }
-
   return pathname
 }
 
-// Check if the given pathname likely a directory
 function isDirectoryPath (pathname) {
   return /\/$/.test(pathname)
 }


### PR DESCRIPTION
This PR is more appropriate implementation to handle omitted trailing slash.  It will redirect if the trailing slash is omitted instead of processing in the same request. 

This nullifies #13 