### PR TITLE
Use caches in build process

### DIFF
--- a/lib/cache-stream.js
+++ b/lib/cache-stream.js
@@ -1,0 +1,79 @@
+'use strict'
+
+const Transform = require('stream').Transform
+
+module.exports = function (cache, depResolver, requestFile) {
+  const contentsMap = new Map()
+
+  function shouldTransform (fileName, source) {
+    contentsMap.set(fileName, source)
+
+    // If original source is updated, it should be transformed
+    if (!cache.test(fileName, source)) {
+      cache.register(fileName, source)
+      return true
+    }
+
+    // Acquire old deps and new deps to compare
+    const oldDeps = depResolver.getOutDeps(fileName)
+    depResolver.register(fileName, source)
+    const newDeps = depResolver.getOutDeps(fileName)
+
+    // If dependencies are not matched, it should be transformed
+    if (!isSameSet(oldDeps, newDeps)) return true
+
+    // Loop through deps to compare its contents
+    let isUpdate = false
+    for (const fileName of newDeps) {
+
+      // If contentsMap has the previously loaded contents, just use it
+      let contents
+      if (contentsMap.has(fileName)) {
+        contents = contentsMap.get(fileName)
+      } else {
+        contents = requestFile(fileName)
+        contentsMap.set(fileName, contents)
+      }
+
+      // What should we do if possible deps are not found?
+      // For now, treat it as updated contents
+      // so that transformers can handle the error
+      if (contents == null) {
+        isUpdate = true
+      } else {
+        isUpdate |= !cache.test(fileName, contents)
+        cache.register(fileName, contents)
+      }
+
+      // If any of the deps contents are updated, should be transformed
+      if (isUpdate) return true
+    }
+
+    // All deps are not updated
+    return false
+  }
+
+  const stream = new Transform({
+    objectMode: true,
+    transform (file, encoding, callback) {
+      const source = file.contents.toString()
+
+      if (shouldTransform(file.path, source)) {
+        callback(null, file)
+      } else {
+        callback()
+      }
+    }
+  })
+
+  return stream
+}
+
+function isSameSet (xs, ys) {
+  if (xs.length !== ys.length) return false
+
+  for (const x of xs) {
+    if (ys.indexOf(x) < 0) return false
+  }
+  return true
+}

--- a/lib/cache-stream.js
+++ b/lib/cache-stream.js
@@ -44,13 +44,9 @@ module.exports = function (cache, depResolver, requestFile) {
         isUpdate |= !cache.test(fileName, contents)
         cache.register(fileName, contents)
       }
-
-      // If any of the deps contents are updated, should be transformed
-      if (isUpdate) return true
     }
 
-    // All deps are not updated
-    return false
+    return isUpdate
   }
 
   const stream = new Transform({

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,15 +1,17 @@
 'use strict'
 
 const assert = require('assert')
+const util = require('./util')
 
 class Cache {
-  constructor () {
+  constructor (transform) {
     this.map = {}
+    this.transform = transform || util.identity
   }
 
   register (filename, contents) {
     assert(typeof filename === 'string', 'File name must be a string')
-    this.map[filename] = contents
+    this.map[filename] = this.transform(contents)
   }
 
   clear (filename) {
@@ -19,7 +21,7 @@ class Cache {
 
   test (filename, contents) {
     assert(typeof filename === 'string', 'File name must be a string')
-    return this.map[filename] === contents
+    return this.map[filename] === this.transform(contents)
   }
 
   serialize () {

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -25,15 +25,11 @@ class Cache {
   }
 
   serialize () {
-    return JSON.stringify(this.map)
+    return this.map
   }
 
-  deserialize (json) {
-    assert(
-      typeof json === 'string',
-      '1st argument of Cache#deserialize must be a json string'
-    )
-    this.map = JSON.parse(json)
+  deserialize (map) {
+    this.map = map
   }
 }
 module.exports = Cache

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const assert = require('assert')
+
+class Cache {
+  constructor () {
+    this.map = {}
+  }
+
+  register (filename, contents) {
+    assert(typeof filename === 'string', 'File name must be a string')
+    this.map[filename] = contents
+  }
+
+  clear (filename) {
+    assert(typeof filename === 'string', 'File name must be a string')
+    delete this.map[filename]
+  }
+
+  test (filename, contents) {
+    assert(typeof filename === 'string', 'File name must be a string')
+    return this.map[filename] === contents
+  }
+
+  serialize () {
+    return JSON.stringify(this.map)
+  }
+
+  deserialize (json) {
+    assert(
+      typeof json === 'string',
+      '1st argument of Cache#deserialize must be a json string'
+    )
+    this.map = JSON.parse(json)
+  }
+}
+module.exports = Cache

--- a/lib/cli/build.js
+++ b/lib/cli/build.js
@@ -4,6 +4,7 @@ const assert = require('assert')
 const path = require('path')
 const vfs = require('vinyl-fs')
 const progeny = require('progeny')
+const hashSum = require('hash-sum')
 const loadConfig = require('../config').loadConfig
 const findConfig = require('../config').findConfig
 const Cache = require('../cache')
@@ -43,7 +44,7 @@ exports.handler = argv => {
   if (argv.cache) {
     const cacheData = util.readFileSync(argv.cache)
 
-    const cache = new Cache()
+    const cache = new Cache(hashSum)
 
     const progenyOptions = util.mapValues(config.rules, rule => rule.progeny)
     const depResolver = new DepResolver((fileName, contents) => {

--- a/lib/cli/build.js
+++ b/lib/cli/build.js
@@ -1,15 +1,24 @@
 'use strict'
 
 const assert = require('assert')
+const path = require('path')
 const vfs = require('vinyl-fs')
+const progeny = require('progeny')
 const loadConfig = require('../config').loadConfig
 const findConfig = require('../config').findConfig
+const Cache = require('../cache')
+const DepResolver = require('../dep-resolver').DepResolver
 const processTask = require('../process-task')
+const cacheStream = require('../cache-stream')
+const util = require('../util')
 
 exports.builder = {
   config: {
     alias: 'c',
     describe: 'Path to a houl config file'
+  },
+  cache: {
+    describe: 'Path to a houl cache file'
   },
   production: {
     describe: 'Enable production mode',
@@ -29,7 +38,44 @@ exports.handler = argv => {
   // TODO: Execute pre tasks
 
   // Process all files in input directory
-  vfs.src(config.vinylInput, { nodir: true })
-    .pipe(processTask(config))
-    .pipe(vfs.dest(config.output))
+  let stream = vfs.src(config.vinylInput, { nodir: true })
+
+  if (argv.cache) {
+    const cacheData = util.readFileSync(argv.cache)
+
+    const cache = new Cache()
+
+    const progenyOptions = util.mapValues(config.rules, rule => rule.progeny)
+    const depResolver = new DepResolver((fileName, contents) => {
+      const ext = path.extname(fileName).slice(1)
+      return progeny.Sync(progenyOptions[ext])(fileName, contents)
+    })
+
+    if (cacheData) {
+      const json = JSON.parse(cacheData)
+
+      // Restore cache data
+      cache.deserialize(json.cache)
+
+      // Restore deps data
+      depResolver.deserialize(json.deps)
+    }
+
+    stream = stream.pipe(cacheStream(cache, depResolver, util.readFileSync))
+
+    // Save cache
+    stream.on('end', () => {
+      const serialized = JSON.stringify({
+        cache: cache.serialize(),
+        deps: depResolver.serialize()
+      })
+      util.writeFileSync(argv.cache, serialized)
+    })
+  }
+
+  // Transform inputs with rules
+  stream = stream.pipe(processTask(config))
+
+  // Output
+  stream.pipe(vfs.dest(config.output))
 }

--- a/lib/cli/dev.js
+++ b/lib/cli/dev.js
@@ -51,7 +51,7 @@ exports.handler = argv => {
       const target = resolveOutput(fullPath)
 
       // Resolve depended files
-      const reloadFiles = [target, ...resolver.resolve(fullPath).map(resolveOutput)]
+      const reloadFiles = [target, ...resolver.getInDeps(fullPath).map(resolveOutput)]
 
       bs.reload(reloadFiles)
     })

--- a/lib/dep-resolver.js
+++ b/lib/dep-resolver.js
@@ -23,24 +23,18 @@ class DepResolver {
 
   getInDeps (fileName) {
     const origin = this._getFile(fileName)
-    const footprints = new Set()
-    footprints.add(origin.fileName)
+    return origin.inDeps.reduce(
+      this._resolveNestedDeps(origin, 'inDeps'),
+      []
+    )
+  }
 
-    const resolveImpl = (acc, fileName) => {
-      const file = this._getFile(fileName)
-
-      // detect circlar deps
-      if (footprints.has(file.fileName)) {
-        return acc
-      }
-
-      footprints.add(file.fileName)
-
-      return file.inDeps
-        .reduce(resolveImpl, acc.concat([file.fileName]))
-    }
-
-    return origin.inDeps.reduce(resolveImpl, [])
+  getOutDeps (fileName) {
+    const origin = this._getFile(fileName)
+    return origin.outDeps.reduce(
+      this._resolveNestedDeps(origin, 'outDeps'),
+      []
+    )
   }
 
   serialize () {
@@ -106,5 +100,31 @@ class DepResolver {
       this._setFile(dep.fileName, dep)
     })
   }
+
+  _resolveNestedDeps (file, depDirection) {
+    assert(
+      depDirection === 'outDeps' || depDirection === 'inDeps'
+    )
+
+    const footprints = new Set()
+    footprints.add(file.fileName)
+
+    const resolveImpl = (acc, fileName) => {
+      const file = this._getFile(fileName)
+
+      // detect circlar deps
+      if (footprints.has(file.fileName)) {
+        return acc
+      }
+
+      footprints.add(file.fileName)
+
+      return file[depDirection]
+        .reduce(resolveImpl, acc.concat([file.fileName]))
+    }
+
+    return resolveImpl
+  }
+
 }
 exports.DepResolver = DepResolver

--- a/lib/dep-resolver.js
+++ b/lib/dep-resolver.js
@@ -44,16 +44,10 @@ class DepResolver {
       map[item.fileName] = item.outDeps
     }
 
-    return JSON.stringify(map)
+    return map
   }
 
-  deserialize (json) {
-    assert(
-      typeof json === 'string',
-      '1st argument of DepResolver#deserialize should be a json string'
-    )
-
-    const map = JSON.parse(json)
+  deserialize (map) {
     this.files.clear()
 
     Object.keys(map).forEach(key => {

--- a/lib/dep-resolver.js
+++ b/lib/dep-resolver.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const assert = require('assert')
+
 class DepResolver {
   constructor (resolveDeps) {
     // `progeny` - (filePath, fileContent) => filePath[]
@@ -39,6 +41,34 @@ class DepResolver {
     }
 
     return origin.inDeps.reduce(resolveImpl, [])
+  }
+
+  serialize () {
+    const map = {}
+
+    for (const item of this.files.values()) {
+      map[item.fileName] = item.outDeps
+    }
+
+    return JSON.stringify(map)
+  }
+
+  deserialize (json) {
+    assert(
+      typeof json === 'string',
+      '1st argument of DepResolver#deserialize should be a json string'
+    )
+
+    const map = JSON.parse(json)
+    this.files.clear()
+
+    Object.keys(map).forEach(key => {
+      const file = this._getFile(key)
+      file.outDeps = map[key]
+
+      this._registerOutDeps(file)
+      this._setFile(key, file)
+    })
   }
 
   _getFile (fileName) {

--- a/lib/dep-resolver.js
+++ b/lib/dep-resolver.js
@@ -21,7 +21,7 @@ class DepResolver {
     this._setFile(fileName, file)
   }
 
-  resolve (fileName) {
+  getInDeps (fileName) {
     const origin = this._getFile(fileName)
     const footprints = new Set()
     footprints.add(origin.fileName)

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const fs = require('fs')
+
 function clone (obj) {
   const res = {}
   Object.keys(obj).forEach(key => {
@@ -29,4 +31,16 @@ exports.mapValues = (val, fn) => {
 
 exports.isLocalPath = pathname => {
   return /^[\.\/]/.test(pathname)
+}
+
+exports.readFileSync = fileName => {
+  try {
+    return fs.readFileSync(fileName, 'utf8')
+  } catch (err) {
+    return undefined
+  }
+}
+
+exports.writeFileSync = (fileName, data) => {
+  fs.writeFileSync(fileName, data)
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "browser-sync": "^2.18.7",
     "chokidar": "^1.6.1",
+    "hash-sum": "^1.0.2",
     "mime": "^1.3.4",
     "minimatch": "^3.0.3",
     "progeny": "^0.11.0",

--- a/test/specs/cache-stream.spec.js
+++ b/test/specs/cache-stream.spec.js
@@ -46,14 +46,14 @@ describe('Cache Stream', () => {
     const cache = new Cache()
     const depResolver = new DepResolver(() => ['bar.txt'])
 
-    cache.deserialize(JSON.stringify({
+    cache.deserialize({
       'foo.txt': 'abc',
       'bar.txt': 'def'
-    }))
+    })
 
-    depResolver.deserialize(JSON.stringify({
+    depResolver.deserialize({
       'foo.txt': ['bar.txt']
-    }))
+    })
 
     const mockFs = pathName => {
       return {
@@ -80,15 +80,15 @@ describe('Cache Stream', () => {
     const cache = new Cache()
     const depResolver = new DepResolver(() => ['baz.txt'])
 
-    cache.deserialize(JSON.stringify({
+    cache.deserialize({
       'foo.txt': 'abc',
       'bar.txt': 'def',
       'baz.txt': 'ghi'
-    }))
+    })
 
-    depResolver.deserialize(JSON.stringify({
+    depResolver.deserialize({
       'foo.txt': ['bar.txt']
-    }))
+    })
 
     const mockFs = pathName => {
       return {
@@ -116,14 +116,14 @@ describe('Cache Stream', () => {
     const cache = new Cache()
     const depResolver = new DepResolver(() => ['bar.txt'])
 
-    cache.deserialize(JSON.stringify({
+    cache.deserialize({
       'foo.txt': 'abc',
       'bar.txt': 'def'
-    }))
+    })
 
-    depResolver.deserialize(JSON.stringify({
+    depResolver.deserialize({
       'foo.txt': ['bar.txt']
-    }))
+    })
 
     const mockFs = pathName => {
       return {
@@ -150,14 +150,14 @@ describe('Cache Stream', () => {
     const cache = new Cache()
     const depResolver = new DepResolver(() => ['bar.txt'])
 
-    cache.deserialize(JSON.stringify({
+    cache.deserialize({
       'foo.txt': 'abc',
       'bar.txt': 'edf'
-    }))
+    })
 
-    depResolver.deserialize(JSON.stringify({
+    depResolver.deserialize({
       'foo.txt': ['bar.txt']
-    }))
+    })
 
     const mockFs = pathName => {
       return {

--- a/test/specs/cache-stream.spec.js
+++ b/test/specs/cache-stream.spec.js
@@ -1,0 +1,206 @@
+'use strict'
+
+const Readable = require('stream').Readable
+const Writable = require('stream').Writable
+const Cache = require('../../lib/cache')
+const DepResolver = require('../../lib/dep-resolver').DepResolver
+const cacheStream = require('../../lib/cache-stream')
+
+const emptyArray = () => []
+const emptyStr = () => ''
+
+describe('Cache Stream', () => {
+  it('does not pass a file having exactly same path and contents', done => {
+    const cache = new Cache()
+    const depResolver = new DepResolver(emptyArray)
+
+    source([
+      { path: 'foo.txt', contents: 'abc' },
+      { path: 'bar.txt', contents: 'def' },
+      { path: 'foo.txt', contents: 'abc' }
+    ]).pipe(cacheStream(cache, depResolver, emptyStr))
+      .pipe(assertStream([
+        { path: 'foo.txt', contents: 'abc' },
+        { path: 'bar.txt', contents: 'def' }
+      ]))
+      .on('finish', done)
+  })
+
+  it('updates cache by latter data', done => {
+    const cache = new Cache()
+    const depResolver = new DepResolver(emptyArray)
+
+    source([
+      { path: 'foo.txt', contents: 'abc' },
+      { path: 'foo.txt', contents: 'edf' },
+      { path: 'foo.txt', contents: 'edf' }
+    ]).pipe(cacheStream(cache, depResolver, emptyStr))
+      .pipe(assertStream([
+        { path: 'foo.txt', contents: 'abc' },
+        { path: 'foo.txt', contents: 'edf' }
+      ]))
+      .on('finish', done)
+  })
+
+  it('passes data if original source does not hit with cache', done => {
+    const cache = new Cache()
+    const depResolver = new DepResolver(() => ['bar.txt'])
+
+    cache.deserialize(JSON.stringify({
+      'foo.txt': 'abc',
+      'bar.txt': 'def'
+    }))
+
+    depResolver.deserialize(JSON.stringify({
+      'foo.txt': ['bar.txt']
+    }))
+
+    const mockFs = pathName => {
+      return {
+        'foo.txt': 'updated',
+        'bar.txt': 'def'
+      }[pathName]
+    }
+
+    // Shold foo.txt be updated?
+    // contents      -> updated
+    // deps          -> not updated
+    // deps contents -> not updated
+    // -> should be updated
+    source([
+      { path: 'foo.txt', contents: 'updated' }
+    ]).pipe(cacheStream(cache, depResolver, mockFs))
+      .pipe(assertStream([
+        { path: 'foo.txt', contents: 'updated' }
+      ]))
+      .on('finish', done)
+  })
+
+  it('passes data if deps are updated', done => {
+    const cache = new Cache()
+    const depResolver = new DepResolver(() => ['baz.txt'])
+
+    cache.deserialize(JSON.stringify({
+      'foo.txt': 'abc',
+      'bar.txt': 'def',
+      'baz.txt': 'ghi'
+    }))
+
+    depResolver.deserialize(JSON.stringify({
+      'foo.txt': ['bar.txt']
+    }))
+
+    const mockFs = pathName => {
+      return {
+        'foo.txt': 'abc',
+        'bar.txt': 'def',
+        'baz.txt': 'ghi'
+      }[pathName]
+    }
+
+    // Shold foo.txt be updated?
+    // contents      -> not updated
+    // deps          -> updated (bar.txt -> baz.txt)
+    // deps contents -> not updated all
+    // -> should be updated
+    source([
+      { path: 'foo.txt', contents: 'abc' }
+    ]).pipe(cacheStream(cache, depResolver, mockFs))
+      .pipe(assertStream([
+        { path: 'foo.txt', contents: 'abc' }
+      ]))
+      .on('finish', done)
+  })
+
+  it('passes data if deps contents are updated', done => {
+    const cache = new Cache()
+    const depResolver = new DepResolver(() => ['bar.txt'])
+
+    cache.deserialize(JSON.stringify({
+      'foo.txt': 'abc',
+      'bar.txt': 'def'
+    }))
+
+    depResolver.deserialize(JSON.stringify({
+      'foo.txt': ['bar.txt']
+    }))
+
+    const mockFs = pathName => {
+      return {
+        'foo.txt': 'abc',
+        'bar.txt': 'updated'
+      }[pathName]
+    }
+
+    // Shold foo.txt be updated?
+    // contents      -> not updated
+    // deps          -> not updated
+    // deps contents -> updated (bar.txt)
+    // -> should be updated
+    source([
+      { path: 'foo.txt', contents: 'abc' }
+    ]).pipe(cacheStream(cache, depResolver, mockFs))
+      .pipe(assertStream([
+        { path: 'foo.txt', contents: 'abc' }
+      ]))
+      .on('finish', done)
+  })
+
+  it('filters data if there are no update in any processes', done => {
+    const cache = new Cache()
+    const depResolver = new DepResolver(() => ['bar.txt'])
+
+    cache.deserialize(JSON.stringify({
+      'foo.txt': 'abc',
+      'bar.txt': 'edf'
+    }))
+
+    depResolver.deserialize(JSON.stringify({
+      'foo.txt': ['bar.txt']
+    }))
+
+    const mockFs = pathName => {
+      return {
+        'foo.txt': 'abc',
+        'bar.txt': 'edf'
+      }[pathName]
+    }
+
+    // Shold foo.txt be updated?
+    // contents      -> not updated
+    // deps          -> not updated
+    // deps contents -> not updated
+    // -> should not be updated
+    source([
+      { path: 'foo.txt', contents: 'abc' }
+    ]).pipe(cacheStream(cache, depResolver, mockFs))
+      .pipe(assertStream([]))
+      .on('finish', done)
+  })
+})
+
+function assertStream (expected) {
+  let count = 0
+
+  return new Writable({
+    objectMode: true,
+    write (data, encoding, cb) {
+      expect(data).toEqual(expected[count])
+
+      count += 1
+      cb(null, data)
+    }
+  }).on('finish', () => {
+    expect(count).toBe(expected.length)
+  })
+}
+
+function source (input) {
+  return new Readable({
+    objectMode: true,
+    read () {
+      input.forEach(data => this.push(data))
+      this.push(null)
+    }
+  })
+}

--- a/test/specs/cache.spec.js
+++ b/test/specs/cache.spec.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const Cache = require('../../lib/cache')
+
+describe('Cache', () => {
+  it('tests cache hit with file name and contents', () => {
+    const cache = new Cache()
+
+    cache.register('test.txt', 'abc')
+
+    expect(cache.test('test.txt', 'abc')).toBe(true)
+    expect(cache.test('foo.txt', 'abc')).toBe(false)
+    expect(cache.test('test.txt', 'def')).toBe(false)
+  })
+
+  it('clears cache by file name', () => {
+    const cache = new Cache()
+
+    cache.register('test.txt', 'abc')
+    expect(cache.test('test.txt', 'abc')).toBe(true)
+
+    cache.clear('test.txt')
+    expect(cache.test('test.txt', 'abc')).toBe(false)
+  })
+
+  it('serializes cache map', () => {
+    const cache = new Cache()
+
+    cache.register('foo.txt', 'abc')
+    cache.register('bar.txt', 'def')
+
+    expect(cache.serialize()).toEqual(JSON.stringify({
+      'foo.txt': 'abc',
+      'bar.txt': 'def'
+    }))
+  })
+
+  it('deserializes cache map', () => {
+    const cache = new Cache()
+
+    cache.deserialize(JSON.stringify({
+      'foo.txt': 'abc',
+      'bar.txt': 'def'
+    }))
+
+    expect(cache.test('foo.txt', 'abc')).toBe(true)
+    expect(cache.test('bar.txt', 'def')).toBe(true)
+  })
+})

--- a/test/specs/cache.spec.js
+++ b/test/specs/cache.spec.js
@@ -46,4 +46,15 @@ describe('Cache', () => {
     expect(cache.test('foo.txt', 'abc')).toBe(true)
     expect(cache.test('bar.txt', 'def')).toBe(true)
   })
+
+  it('hashes cache data by provided transformer', () => {
+    const cache = new Cache(content => 'abc' + content)
+
+    cache.register('foo.txt', 'def')
+
+    expect(cache.test('foo.txt', 'def')).toBe(true)
+    expect(cache.serialize()).toEqual(JSON.stringify({
+      'foo.txt': 'abcdef'
+    }))
+  })
 })

--- a/test/specs/cache.spec.js
+++ b/test/specs/cache.spec.js
@@ -29,19 +29,19 @@ describe('Cache', () => {
     cache.register('foo.txt', 'abc')
     cache.register('bar.txt', 'def')
 
-    expect(cache.serialize()).toEqual(JSON.stringify({
+    expect(cache.serialize()).toEqual({
       'foo.txt': 'abc',
       'bar.txt': 'def'
-    }))
+    })
   })
 
   it('deserializes cache map', () => {
     const cache = new Cache()
 
-    cache.deserialize(JSON.stringify({
+    cache.deserialize({
       'foo.txt': 'abc',
       'bar.txt': 'def'
-    }))
+    })
 
     expect(cache.test('foo.txt', 'abc')).toBe(true)
     expect(cache.test('bar.txt', 'def')).toBe(true)
@@ -53,8 +53,8 @@ describe('Cache', () => {
     cache.register('foo.txt', 'def')
 
     expect(cache.test('foo.txt', 'def')).toBe(true)
-    expect(cache.serialize()).toEqual(JSON.stringify({
+    expect(cache.serialize()).toEqual({
       'foo.txt': 'abcdef'
-    }))
+    })
   })
 })

--- a/test/specs/dep-resolver.spec.js
+++ b/test/specs/dep-resolver.spec.js
@@ -88,6 +88,21 @@ describe('DepResolver', () => {
     expect(r.getInDeps('/test.js')).toEqual([])
   })
 
+  it('provides nested out deps', () => {
+    const r = new DepResolver((_, content) => [content])
+
+    // a --> b -> d
+    // c -^
+    r.register('/a.js', '/b.js')
+    r.register('/c.js', '/b.js')
+    r.register('/b.js', '/d.js')
+
+    expect(r.getOutDeps('/a.js')).toEqual([
+      '/b.js',
+      '/d.js'
+    ])
+  })
+
   it('serializes deps', () => {
     const r = new DepResolver(() => ['/baz.js'])
 

--- a/test/specs/dep-resolver.spec.js
+++ b/test/specs/dep-resolver.spec.js
@@ -8,14 +8,14 @@ describe('DepResolver', () => {
 
     // origin.js -depends-> dep.js
     r.register('/path/to/origin.js', '')
-    expect(r.resolve('/path/to/dep.js')).toEqual([
+    expect(r.getInDeps('/path/to/dep.js')).toEqual([
       '/path/to/origin.js'
     ])
 
     // origin.js  -depends--> dep.js
     // another.js -depends-^
     r.register('/path/to/another.js', '')
-    expect(r.resolve('/path/to/dep.js')).toEqual([
+    expect(r.getInDeps('/path/to/dep.js')).toEqual([
       '/path/to/origin.js',
       '/path/to/another.js'
     ])
@@ -27,7 +27,7 @@ describe('DepResolver', () => {
     r.register('/path/to/origin.js', '')
     r.register('/path/to/origin.js', '')
 
-    expect(r.resolve('/path/to/dep.js')).toEqual([
+    expect(r.getInDeps('/path/to/dep.js')).toEqual([
       '/path/to/origin.js'
     ])
   })
@@ -41,7 +41,7 @@ describe('DepResolver', () => {
     r.register('/c.js', '/b.js')
     r.register('/b.js', '/d.js')
 
-    expect(r.resolve('/d.js')).toEqual([
+    expect(r.getInDeps('/d.js')).toEqual([
       '/b.js',
       '/a.js',
       '/c.js'
@@ -56,7 +56,7 @@ describe('DepResolver', () => {
     r.register('/b.js', '/c.js')
     r.register('/c.js', '/a.js')
 
-    expect(r.resolve('/a.js')).toEqual([
+    expect(r.getInDeps('/a.js')).toEqual([
       '/c.js',
       '/b.js'
     ])
@@ -69,23 +69,23 @@ describe('DepResolver', () => {
     // bar -^
     r.register('/foo.js', '/test.js')
     r.register('/bar.js', '/test.js')
-    expect(r.resolve('/test.js')).toEqual([
+    expect(r.getInDeps('/test.js')).toEqual([
       '/foo.js',
       '/bar.js'
     ])
 
     r.register('/foo.js', '/test2.js')
-    expect(r.resolve('/test.js')).toEqual([
+    expect(r.getInDeps('/test.js')).toEqual([
       '/bar.js'
     ])
-    expect(r.resolve('/test2.js')).toEqual([
+    expect(r.getInDeps('/test2.js')).toEqual([
       '/foo.js'
     ])
   })
 
   it('returns empty array if target is not registered', () => {
     const r = new DepResolver(() => ['noop'])
-    expect(r.resolve('/test.js')).toEqual([])
+    expect(r.getInDeps('/test.js')).toEqual([])
   })
 
   it('serializes deps', () => {
@@ -111,7 +111,7 @@ describe('DepResolver', () => {
       '/bar.js': ['/baz.js']
     }))
 
-    expect(r.resolve('/baz.js')).toEqual([
+    expect(r.getInDeps('/baz.js')).toEqual([
       '/foo.js',
       '/bar.js'
     ])

--- a/test/specs/dep-resolver.spec.js
+++ b/test/specs/dep-resolver.spec.js
@@ -111,20 +111,20 @@ describe('DepResolver', () => {
     r.register('/foo.js', '')
     r.register('/bar.js', '')
 
-    expect(r.serialize()).toBe(JSON.stringify({
+    expect(r.serialize()).toEqual({
       '/foo.js': ['/baz.js'],
-      '/baz.js': [],
-      '/bar.js': ['/baz.js']
-    }))
+      '/bar.js': ['/baz.js'],
+      '/baz.js': []
+    })
   })
 
   it('deserializes deps', () => {
     const r = new DepResolver(() => [])
 
-    r.deserialize(JSON.stringify({
+    r.deserialize({
       '/foo.js': ['/baz.js'],
       '/bar.js': ['/baz.js']
-    }))
+    })
 
     expect(r.getInDeps('/baz.js')).toEqual([
       '/foo.js',

--- a/test/specs/dep-resolver.spec.js
+++ b/test/specs/dep-resolver.spec.js
@@ -87,4 +87,33 @@ describe('DepResolver', () => {
     const r = new DepResolver(() => ['noop'])
     expect(r.resolve('/test.js')).toEqual([])
   })
+
+  it('serializes deps', () => {
+    const r = new DepResolver(() => ['/baz.js'])
+
+    // foo --> baz
+    // bar -^
+    r.register('/foo.js', '')
+    r.register('/bar.js', '')
+
+    expect(r.serialize()).toBe(JSON.stringify({
+      '/foo.js': ['/baz.js'],
+      '/baz.js': [],
+      '/bar.js': ['/baz.js']
+    }))
+  })
+
+  it('deserializes deps', () => {
+    const r = new DepResolver(() => [])
+
+    r.deserialize(JSON.stringify({
+      '/foo.js': ['/baz.js'],
+      '/bar.js': ['/baz.js']
+    }))
+
+    expect(r.resolve('/baz.js')).toEqual([
+      '/foo.js',
+      '/bar.js'
+    ])
+  })
 })


### PR DESCRIPTION
This is the first step to use a cache of previous build in `houl build`. With this feature, we can skip to transform files that does not updated from previous build including its dependencies. To use this feature, we need to specify `--cache` option with the path of cache file.

```bash
$ houl build --cache .houlcache
```

The cache file is just a json file including a hash of file and its dependencies. If `--cache` is specified, houl will load the cache file and restore the hash and dependencies, then compare them during build process.

The test cases may not fulfill all possible cases but it just works for all simple cases as far as I can see.