### PR TITLE
Fix cache strategy to ensure always save all possible deps' cache

### DIFF
--- a/lib/cache-stream.js
+++ b/lib/cache-stream.js
@@ -22,13 +22,8 @@ module.exports = function (cache, depResolver, requestFile) {
     // If original source is updated, it should be transformed
     if (!cache.test(fileName, source)) return true
 
-    // Acquire old deps and new deps to compare
-    const oldDeps = depResolver.getOutDeps(fileName)
     depResolver.register(fileName, source)
     const newDeps = depResolver.getOutDeps(fileName)
-
-    // If dependencies are not matched, it should be transformed
-    if (!isSameSet(oldDeps, newDeps)) return true
 
     // Loop through deps to compare its contents
     let isUpdate = false
@@ -88,13 +83,4 @@ module.exports = function (cache, depResolver, requestFile) {
   })
 
   return stream
-}
-
-function isSameSet (xs, ys) {
-  if (xs.length !== ys.length) return false
-
-  for (const x of xs) {
-    if (ys.indexOf(x) < 0) return false
-  }
-  return true
 }

--- a/lib/cache-stream.js
+++ b/lib/cache-stream.js
@@ -5,14 +5,22 @@ const Transform = require('stream').Transform
 module.exports = function (cache, depResolver, requestFile) {
   const contentsMap = new Map()
 
+  function getContent (fileName) {
+    // If contentsMap has the previously loaded contents, just use it
+    if (contentsMap.has(fileName)) {
+      return contentsMap.get(fileName)
+    } else {
+      const contents = requestFile(fileName)
+      contentsMap.set(fileName, contents)
+      return contents
+    }
+  }
+
   function shouldTransform (fileName, source) {
     contentsMap.set(fileName, source)
 
     // If original source is updated, it should be transformed
-    if (!cache.test(fileName, source)) {
-      cache.register(fileName, source)
-      return true
-    }
+    if (!cache.test(fileName, source)) return true
 
     // Acquire old deps and new deps to compare
     const oldDeps = depResolver.getOutDeps(fileName)
@@ -25,15 +33,7 @@ module.exports = function (cache, depResolver, requestFile) {
     // Loop through deps to compare its contents
     let isUpdate = false
     for (const fileName of newDeps) {
-
-      // If contentsMap has the previously loaded contents, just use it
-      let contents
-      if (contentsMap.has(fileName)) {
-        contents = contentsMap.get(fileName)
-      } else {
-        contents = requestFile(fileName)
-        contentsMap.set(fileName, contents)
-      }
+      const contents = getContent(fileName)
 
       // What should we do if possible deps are not found?
       // For now, treat it as updated contents
@@ -42,11 +42,29 @@ module.exports = function (cache, depResolver, requestFile) {
         isUpdate = true
       } else {
         isUpdate |= !cache.test(fileName, contents)
-        cache.register(fileName, contents)
       }
     }
 
     return isUpdate
+  }
+
+  function walkNestedDeps (fileName, source) {
+    const footprints = new Set()
+
+    function loop (fileName, source) {
+      // Detect circular
+      if (footprints.has(fileName)) return
+      footprints.add(fileName)
+
+      cache.register(fileName, source)
+      depResolver.register(fileName, source)
+
+      depResolver.getOutDeps(fileName).forEach(fileName => {
+        loop(fileName, getContent(fileName))
+      })
+    }
+
+    return loop(fileName, source)
   }
 
   const stream = new Transform({
@@ -55,10 +73,17 @@ module.exports = function (cache, depResolver, requestFile) {
       const source = file.contents.toString()
 
       if (shouldTransform(file.path, source)) {
-        callback(null, file)
-      } else {
-        callback()
+        this.push(file)
       }
+
+      callback()
+    }
+  })
+
+  stream.on('finish', () => {
+    // Update cache and deps
+    for (const entry of contentsMap.entries()) {
+      walkNestedDeps(entry[0], entry[1])
     }
   })
 

--- a/test/specs/cache-stream.spec.js
+++ b/test/specs/cache-stream.spec.js
@@ -105,42 +105,6 @@ describe('Cache Stream', () => {
       .on('finish', done)
   })
 
-  it('passes data if deps are updated', done => {
-    const cache = new Cache()
-    const depResolver = new DepResolver(() => ['baz.txt'])
-
-    cache.deserialize({
-      'foo.txt': 'abc',
-      'bar.txt': 'def',
-      'baz.txt': 'ghi'
-    })
-
-    depResolver.deserialize({
-      'foo.txt': ['bar.txt']
-    })
-
-    const mockFs = pathName => {
-      return {
-        'foo.txt': 'abc',
-        'bar.txt': 'def',
-        'baz.txt': 'ghi'
-      }[pathName]
-    }
-
-    // Shold foo.txt be updated?
-    // contents      -> not updated
-    // deps          -> updated (bar.txt -> baz.txt)
-    // deps contents -> not updated all
-    // -> should be updated
-    source([
-      { path: 'foo.txt', contents: 'abc' }
-    ]).pipe(cacheStream(cache, depResolver, mockFs))
-      .pipe(assertStream([
-        { path: 'foo.txt', contents: 'abc' }
-      ]))
-      .on('finish', done)
-  })
-
   it('passes data if deps contents are updated', done => {
     const cache = new Cache()
     const depResolver = new DepResolver(() => ['bar.txt'])

--- a/test/specs/cache-stream.spec.js
+++ b/test/specs/cache-stream.spec.js
@@ -28,7 +28,7 @@ describe('Cache Stream', () => {
   })
 
 
-  it('should not affect deps update of previous item', done => {
+  it('should not affect latter items even if previous item updates nested deps', done => {
     // last:    a.txt -> b.txt -> c.txt
     // current: a.txt -> b.txt -> d.txt
     // With this structure, if a.txt and b.txt passes to


### PR DESCRIPTION
Fix #16 

This PR makes cache stream to save caches of entire files (including nested deps) in all cases. Previously, it does not save deps if the source file does not hit cache. So I've modified the strategy to resolve and save entire cache and deps after finished the cache stream.

I also noticed we don't have to compare old and new deps since if deps are updated, its contents must also be updated. I've removed relevant codes about that.