### PR TITLE
Remove execute option from config

### DIFF
--- a/lib/cli/build.js
+++ b/lib/cli/build.js
@@ -36,8 +36,6 @@ exports.handler = argv => {
   assert(configPath, 'Config file is not found')
   const config = loadConfig(configPath)
 
-  // TODO: Execute pre tasks
-
   // Process all files in input directory
   let stream = vfs.src(config.vinylInput, { nodir: true })
 

--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -30,15 +30,6 @@ module.exports = class Config {
 
     // Resolve and merge rules by traversing preset
     this.rules = this._resolveRules(config.rules || {}, tasks, preset)
-
-    // Resolve paths in execute options
-    if (Array.isArray(config.execute)) {
-      this.execute = config.execute.map(opts => ({
-        task: opts.task,
-        input: resolve(opts.input),
-        output: resolve(opts.output)
-      }))
-    }
   }
 
   get vinylInput () {

--- a/test/fixtures/configs/normal.config.js
+++ b/test/fixtures/configs/normal.config.js
@@ -13,12 +13,5 @@ module.exports = {
       task: 'task2'
     },
     png: 'imagemin'
-  },
-  execute: [
-    {
-      task: 'svg',
-      input: './src/img/_assets/*.svg',
-      output: './dist/img/share'
-    }
-  ]
+  }
 }

--- a/test/fixtures/configs/preset.config.js
+++ b/test/fixtures/configs/preset.config.js
@@ -9,12 +9,5 @@ module.exports = {
       task: 'bar'
     },
     gif: 'foo'
-  },
-  execute: [
-    {
-      task: 'svg',
-      input: './src/img/_assets/*.svg',
-      output: './dist/img/share'
-    }
-  ]
+  }
 }

--- a/test/specs/models/config.spec.js
+++ b/test/specs/models/config.spec.js
@@ -15,22 +15,6 @@ describe('Config model', () => {
     expect(c.output).toBePath('/path/to/base/to/dist')
   })
 
-  it('resolves paths in execute options based on cwd', () => {
-    const c = new Config({
-      execute: [
-        {
-          input: 'src/img/_assets/*.svg',
-          output: 'dist/img/share'
-        }
-      ]
-    }, {}, {
-      base: '/path/to/'
-    })
-    const e = c.execute[0]
-    expect(e.input).toBePath('/path/to/src/img/_assets/*.svg')
-    expect(e.output).toBePath('/path/to/dist/img/share')
-  })
-
   it('retain exclude field', () => {
     const c = new Config({
       exclude: '**/_*'


### PR DESCRIPTION
This PR stops resolving `execute` option of config file. This is not a breaking change since it just store the option in memory but does not provide any features.

We should use gulp task if we need such task that is not just build source files and output corresponding files.