### PR TITLE
Refactoring task stream to use only internal stream for each rule

### DIFF
--- a/lib/task-stream.js
+++ b/lib/task-stream.js
@@ -1,39 +1,103 @@
 'use strict'
 
-const stream = require('stream')
-const Transform = stream.Transform
-const Readable = stream.Readable
+const Duplex = require('stream').Duplex
+const PassThrough = require('stream').PassThrough
 
 /**
- * Returns a transform stream that branches
- * the input stream to several streams given by argument.
+ * Branch the input files to several streams
+ * to process user defined tasks based on rules.
+ * All processed files are pushed into TaskStream
+ * so the user of this stream should not aware
+ * there are multiple streams under the hood.
  */
-module.exports = function taskStream (config) {
-  /**
-   * (inputStream) -> transform -> each task -> transform -> (outputStream)
-   */
-  return new Transform({
-    objectMode: true,
+class TaskStream extends Duplex {
+  constructor (config) {
+    super({ objectMode: true })
 
-    transform (file, encoding, callback) {
-      const rule = config.findRuleByInput(file.path)
+    this._config = config
 
-      if (rule === null) {
-        callback(null, file)
-        return
-      }
+    // Create transform streams for each rule
+    this._branches = this._createInternalStreams(config)
 
-      const src = new Readable({ objectMode: true })
-      src.push(file)
-      src.push(null)
+    // Teardown
+    this.on('finish', () => this._destroy())
+  }
 
-      rule.task(src)
+  _createInternalStreams (config) {
+    const map = new Map()
+
+    Object.keys(config.rules).forEach(key => {
+      const rule = config.rules[key]
+
+      const input = new PassThrough({
+        objectMode: true
+      })
+
+      const output = rule.task(input)
         .on('data', file => {
           file.extname = '.' + rule.outputExt
-          this.push( file)
+          this.push(file)
         })
-        .on('error', callback)
-        .on('end', callback)
+        .on('error', file => this.emit('error', file))
+
+      // Register the source stream to use later.
+      map.set(rule, { input, output })
+    })
+
+    return map
+  }
+
+  _destroy () {
+    // To ensure to teardown the streams in correct order
+    // we need to wait internal streams before finish `this`.
+    // We have to notify the end of input to input stream of each branch
+    // and listen the `end` event of each output stream
+    // to avoid leakage of any data that need long time to transform.
+    const branches = Array.from(this._branches.values())
+    branches.forEach(b => {
+      b.input.push(null)
+    })
+
+    waitAllStreams(branches.map(b => b.output), () => {
+      this.push(null)
+    })
+  }
+
+  /**
+   * If the file does not match any rules
+   * it is immediately pushed to next stream.
+   * Otherwise it is sent to cooresponding task stream.
+   */
+  _write (file, encoding, done) {
+    const rule = this._config.findRuleByInput(file.path)
+
+    if (rule === null) {
+      this.push(file)
+    } else {
+      const input = this._branches.get(rule).input
+      input.push(file)
     }
-  })
+
+    done()
+  }
+
+  // Do nothing since we just use this.push method in other places
+  _read () {}
+}
+
+function waitAllStreams (streams, done) {
+  let rest = streams.length
+
+  for (const s of streams) {
+    s.on('end', () => {
+      rest -= 1
+      if (rest === 0) {
+        done()
+      }
+    })
+  }
+}
+
+module.exports = function taskStream (config) {
+  return new TaskStream(config)
 }

--- a/test/specs/task-stream.spec.js
+++ b/test/specs/task-stream.spec.js
@@ -16,7 +16,9 @@ describe('ProcessTask Stream', () => {
         js: 'js'
       }
     }, {
-      js: () => { throw new Error('Unexpected') }
+      js: stream => stream.pipe(transform((file, encoding, done) => {
+        done(new Error('Unexpected'))
+      }))
     })
 
     source([


### PR DESCRIPTION
Previously, `TaskStream` module creates internal streams for each file. It probably decrease the performance for each task and cause unexpected behavior if using some plugin (like gulp-imagemin - it will print compaction stats for each file in Houl).

This patch modifies `TaskStream` to only use one stream par task and fix such behaviors.