### PR TITLE
Avoid progeny error when root file of deps is not found

### DIFF
--- a/lib/cache-stream.js
+++ b/lib/cache-stream.js
@@ -51,6 +51,14 @@ module.exports = function (cache, depResolver, requestFile) {
       if (footprints.has(fileName)) return
       footprints.add(fileName)
 
+      // When `source` is empty value,
+      // the file is not exists so we must clear the cache.
+      if (source == null) {
+        cache.clear(fileName)
+        depResolver.clear(fileName)
+        return
+      }
+
       cache.register(fileName, source)
       depResolver.register(fileName, source)
 

--- a/lib/dep-resolver.js
+++ b/lib/dep-resolver.js
@@ -21,6 +21,13 @@ class DepResolver {
     this._setFile(fileName, file)
   }
 
+  clear (fileName) {
+    const file = this._getFile(fileName)
+    this._cleanUpOutDeps(file)
+    this._cleanUpInDeps(file)
+    this._deleteFile(fileName)
+  }
+
   getInDeps (fileName) {
     const origin = this._getFile(fileName)
     return origin.inDeps.reduce(
@@ -77,6 +84,10 @@ class DepResolver {
     this.files.set(fileName, file)
   }
 
+  _deleteFile (fileName) {
+    this.files.delete(fileName)
+  }
+
   _registerOutDeps (file) {
     file.outDeps.forEach(name => {
       const dep = this._getFile(name)
@@ -90,6 +101,16 @@ class DepResolver {
       const dep = this._getFile(name)
       dep.inDeps = dep.inDeps.filter(inDep => {
         return inDep !== file.fileName
+      })
+      this._setFile(dep.fileName, dep)
+    })
+  }
+
+  _cleanUpInDeps (file) {
+    file.inDeps.forEach(name => {
+      const dep = this._getFile(name)
+      dep.outDeps = dep.outDeps.filter(outDep => {
+        return outDep !== file.fileName
       })
       this._setFile(dep.fileName, dep)
     })

--- a/lib/dep-resolver.js
+++ b/lib/dep-resolver.js
@@ -24,7 +24,6 @@ class DepResolver {
   clear (fileName) {
     const file = this._getFile(fileName)
     this._cleanUpOutDeps(file)
-    this._cleanUpInDeps(file)
     this._deleteFile(fileName)
   }
 
@@ -101,16 +100,6 @@ class DepResolver {
       const dep = this._getFile(name)
       dep.inDeps = dep.inDeps.filter(inDep => {
         return inDep !== file.fileName
-      })
-      this._setFile(dep.fileName, dep)
-    })
-  }
-
-  _cleanUpInDeps (file) {
-    file.inDeps.forEach(name => {
-      const dep = this._getFile(name)
-      dep.outDeps = dep.outDeps.filter(outDep => {
-        return outDep !== file.fileName
       })
       this._setFile(dep.fileName, dep)
     })

--- a/test/specs/dep-resolver.spec.js
+++ b/test/specs/dep-resolver.spec.js
@@ -53,11 +53,17 @@ describe('DepResolver', () => {
 
     r.clear('/n.js')
 
-    // b -> a
+    // Should not remove inDeps of `n` because
+    // the deps may still refer `n` even if it has gone.
+    //
+    // a --> (n)
+    // ^  |
+    // b -^
+    //
     // y -> x
     expect(r.serialize()).toEqual({
-      '/a.js': [],
-      '/b.js': ['/a.js'],
+      '/a.js': ['/n.js'],
+      '/b.js': ['/n.js', '/a.js'],
       '/y.js': ['/x.js'],
       '/x.js': []
     })

--- a/test/specs/dep-resolver.spec.js
+++ b/test/specs/dep-resolver.spec.js
@@ -32,6 +32,37 @@ describe('DepResolver', () => {
     ])
   })
 
+  it('clears provided file', () => {
+    const r = new DepResolver((_, content) => content.split(','))
+
+    // a --> n --> x
+    // ^  |    |   ^
+    // b -^     -> y
+    r.register('/a.js', '/n.js')
+    r.register('/b.js', '/n.js,/a.js')
+    r.register('/n.js', '/x.js,/y.js')
+    r.register('/y.js', '/x.js')
+
+    expect(r.serialize()).toEqual({
+      '/a.js': ['/n.js'],
+      '/b.js': ['/n.js', '/a.js'],
+      '/n.js': ['/x.js', '/y.js'],
+      '/y.js': ['/x.js'],
+      '/x.js': []
+    })
+
+    r.clear('/n.js')
+
+    // b -> a
+    // y -> x
+    expect(r.serialize()).toEqual({
+      '/a.js': [],
+      '/b.js': ['/a.js'],
+      '/y.js': ['/x.js'],
+      '/x.js': []
+    })
+  })
+
   it('resolves nested dependencies', () => {
     const r = new DepResolver((_, content) => [content])
 


### PR DESCRIPTION
Fix #26 

In case some nested deps are updated, cached dep files may be refered on teardown phase of cache stream. If the cached dep files does not exist on that time, `undefined` value will be pass `progeny` and it causes file not found error.