### PR TITLE
Allow an empty taskFile field in config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -16,8 +16,6 @@ function loadConfig (configPath, configOptions) {
     ? rawConfig(configOptions || {})
     : rawConfig
 
-  assert(config.taskFile, '"taskFile" must be specified in config file.')
-
   // Unify the `preset` option into the object style
   const preset = typeof config.preset === 'string'
     ? { name: config.preset }
@@ -28,7 +26,9 @@ function loadConfig (configPath, configOptions) {
     options.preset = loadConfig(presetPath, preset.options)
   }
 
-  const tasks = require(path.resolve(base, config.taskFile))
+  const tasks = config.taskFile
+    ? require(path.resolve(base, config.taskFile))
+    : {}
 
   return new Config(config, tasks, options)
 }

--- a/test/fixtures/configs/no-taskfile.js
+++ b/test/fixtures/configs/no-taskfile.js
@@ -1,0 +1,3 @@
+module.exports = {
+  preset: './preset.config.js'
+}

--- a/test/specs/config.spec.js
+++ b/test/specs/config.spec.js
@@ -38,6 +38,12 @@ describe('Config', () => {
     expect(config.rules.baz.task()).toBe('bazOptions')
   })
 
+  it('allows an empty taskFile field', () => {
+    expect(() => {
+      read('no-taskfile.js')
+    }).not.toThrow()
+  })
+
   it('search config file', () => {
     function exists (pathname) {
       return '/path/houl.config.js' === normalize(pathname)


### PR DESCRIPTION
It is valid to leave `taskFile` field empty if the user want to use preset tasks only.