### PR TITLE
Allow to set base path of dev server

### DIFF
--- a/lib/cli/dev.js
+++ b/lib/cli/dev.js
@@ -40,11 +40,14 @@ exports.handler = argv => {
     return progeny.Sync(progenyOptions[ext])(fileName, contents)
   })
 
+  const basePath = argv['base-path']
+
   const bs = create(config, {
     port: argv.port,
+    startPath: basePath,
     logLevel: argv._debug ? 'silent' : 'info', // Internal
     open: !argv._debug // Internal
-  }, resolver, argv['base-path'])
+  }, resolver, basePath)
 
   chokidar.watch(config.input, { ignoreInitial: true, cwd: config.input })
     .on('change', pathname => {

--- a/lib/cli/dev.js
+++ b/lib/cli/dev.js
@@ -20,6 +20,10 @@ exports.builder = {
     describe: 'Port number of dev server',
     default: 3000,
     number: true
+  },
+  'base-path': {
+    describe: 'Base path of dev server',
+    default: '/'
   }
 }
 
@@ -40,7 +44,7 @@ exports.handler = argv => {
     port: argv.port,
     logLevel: argv._debug ? 'silent' : 'info', // Internal
     open: !argv._debug // Internal
-  }, resolver)
+  }, resolver, argv['base-path'])
 
   chokidar.watch(config.input, { ignoreInitial: true, cwd: config.input })
     .on('change', pathname => {

--- a/lib/externals/browser-sync.js
+++ b/lib/externals/browser-sync.js
@@ -43,12 +43,13 @@ function injectMiddleware (options, middleware) {
 
 function createMiddleware (config, depResolver, basePath) {
   return (req, res, next) => {
-    const reqPath = resolveBase(basePath, url.parse(req.url).pathname)
-    if (reqPath === null) {
+    const parsedPath = url.parse(req.url).pathname
+    const reqPath = normalizePath(parsedPath)
+
+    const outputPath = resolveBase(basePath, reqPath)
+    if (outputPath === null) {
       return notFound(res)
     }
-
-    const outputPath = normalizePath(reqPath)
 
     const rule = config.findRuleByOutput(outputPath, inputPath => {
       return fs.existsSync(path.join(config.input, inputPath))

--- a/lib/externals/browser-sync.js
+++ b/lib/externals/browser-sync.js
@@ -14,13 +14,13 @@ const defaultBsOptions = {
   notify: false
 }
 
-module.exports = (config, bsOptions, depResolver) => {
+module.exports = (config, bsOptions, depResolver, basePath) => {
   const bs = browserSync.create()
 
   bsOptions = util.merge(defaultBsOptions, bsOptions)
 
   bsOptions.server = config.output
-  injectMiddleware(bsOptions, createMiddleware(config, depResolver))
+  injectMiddleware(bsOptions, createMiddleware(config, depResolver, basePath))
 
   bs.init(bsOptions)
 
@@ -41,9 +41,13 @@ function injectMiddleware (options, middleware) {
   options.middleware = [middleware]
 }
 
-function createMiddleware (config, depResolver) {
+function createMiddleware (config, depResolver, basePath) {
   return (req, res, next) => {
-    const reqPath = url.parse(req.url).pathname
+    const reqPath = resolveBase(basePath, url.parse(req.url).pathname)
+    if (reqPath === null) {
+      return notFound(res)
+    }
+
     const outputPath = normalizePath(reqPath)
 
     const rule = config.findRuleByOutput(outputPath, inputPath => {
@@ -87,6 +91,31 @@ function redirect (res, pathname) {
   res.end()
 }
 
+function notFound (res) {
+  res.statusCode = 404
+  res.end()
+}
+
+function resolveBase (base, target) {
+  function loop (base, target) {
+    const bh = base[0]
+    if (bh === undefined) {
+      return '/' + target.join('/')
+    }
+
+    const th = target[0]
+    if (bh !== th) {
+      return null
+    }
+
+    return loop(base.slice(1), target.slice(1))
+  }
+
+  const baseList = trimHead(base.split('/'))
+  const targetList = trimHead(target.split('/'))
+  return loop(baseList, targetList)
+}
+
 function normalizePath (pathname) {
   if (isDirectoryPath(pathname)) {
     pathname = path.join(pathname, 'index.html')
@@ -96,4 +125,8 @@ function normalizePath (pathname) {
 
 function isDirectoryPath (pathname) {
   return /\/$/.test(pathname)
+}
+
+function trimHead (list) {
+  return util.dropWhile(list, item => item === '')
 }

--- a/lib/externals/browser-sync.js
+++ b/lib/externals/browser-sync.js
@@ -111,7 +111,7 @@ function resolveBase (base, target) {
     return loop(base.slice(1), target.slice(1))
   }
 
-  const baseList = trimHead(base.split('/'))
+  const baseList = base.split('/').filter(item => item !== '')
   const targetList = trimHead(target.split('/'))
   return loop(baseList, targetList)
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -49,7 +49,7 @@ exports.dropWhile = (list, fn) => {
   let from = 0
   for (let i = 0; i < list.length; i++) {
     if (fn(list[i])) {
-      from = i
+      from = i + 1
     } else {
       break
     }

--- a/lib/util.js
+++ b/lib/util.js
@@ -44,3 +44,15 @@ exports.readFileSync = fileName => {
 exports.writeFileSync = (fileName, data) => {
   fs.writeFileSync(fileName, data)
 }
+
+exports.dropWhile = (list, fn) => {
+  let from = 0
+  for (let i = 0; i < list.length; i++) {
+    if (fn(list[i])) {
+      from = i
+    } else {
+      break
+    }
+  }
+  return list.slice(from)
+}

--- a/test/e2e/dev.spec.js
+++ b/test/e2e/dev.spec.js
@@ -25,6 +25,7 @@ describe('Dev CLI', () => {
     bs = dev({
       config: options.config,
       port: options.port || 3000,
+      'base-path': options['base-path'] || '/',
       _debug: true
     })
 
@@ -101,6 +102,18 @@ describe('Dev CLI', () => {
   it('can be specified port number of dev server', done => {
     run({ config, port: 51234 }, () => {
       get('/js/index.js', 51234, (res, data) => {
+        expect(res.statusCode).toBe(200)
+        assertData(data, 'js/index.js')
+        done()
+      })
+    })
+  })
+
+  it('can be set base path of dev server', done => {
+    const options = { config }
+    options['base-path'] = 'path/to/base'
+    run(options, () => {
+      get('/path/to/base/js/index.js', 3000, (res, data) => {
         expect(res.statusCode).toBe(200)
         assertData(data, 'js/index.js')
         done()

--- a/test/specs/externals/browser-sync.spec.js
+++ b/test/specs/externals/browser-sync.spec.js
@@ -97,7 +97,7 @@ describe('Using browsersync', () => {
         port: 51234,
         open: false,
         logLevel: 'silent'
-      }, mockResolver, '/path/to/base')
+      }, mockResolver, '/path/to/base/')
 
       bs.emitter.on('init', done)
     })

--- a/test/specs/externals/browser-sync.spec.js
+++ b/test/specs/externals/browser-sync.spec.js
@@ -43,49 +43,82 @@ describe('Using browsersync', () => {
   }
 
   let bs
-  beforeAll(done => {
-    bs = create(config, {
-      port: 51234,
-      open: false,
-      logLevel: 'silent'
-    }, mockResolver)
+  describe('without base path', () => {
+    beforeAll(done => {
+      bs = create(config, {
+        port: 51234,
+        open: false,
+        logLevel: 'silent'
+      }, mockResolver, '/')
 
-    bs.emitter.on('init', done)
-  })
+      bs.emitter.on('init', done)
+    })
 
-  afterAll(() => {
-    bs.exit()
-  })
+    afterAll(() => {
+      bs.exit()
+    })
 
-  it('starts dev server by the given port', done => {
-    http.get(reqTo('/sources/'), waitForData((res, data) => {
-      expect(res.statusCode).toBe(200)
-      expectDataToBeFile(data, 'sources/index.html')
-      done()
-    }))
-  })
+    it('starts dev server by the given port', done => {
+      http.get(reqTo('/sources/'), waitForData((res, data) => {
+        expect(res.statusCode).toBe(200)
+        expectDataToBeFile(data, 'sources/index.html')
+        done()
+      }))
+    })
 
-  it('executes corresponding task to transform sources', done => {
-    http.get(reqTo('/sources/index.js'), waitForData((res, data) => {
-      expect(data).toMatch(/^\*\*transformed\*\*\n/)
-      done()
-    }))
-  })
+    it('executes corresponding task to transform sources', done => {
+      http.get(reqTo('/sources/index.js'), waitForData((res, data) => {
+        expect(data).toMatch(/^\*\*transformed\*\*\n/)
+        done()
+      }))
+    })
 
-  it('redirects if the specified path does not have trailing slash and it points to a directory', done => {
-    http.get(reqTo('/sources'), res => {
-      expect(res.statusCode).toBe(301)
-      expect(res.headers.location).toBe('/sources/')
-      done()
+    it('redirects if the specified path does not have trailing slash and it points to a directory', done => {
+      http.get(reqTo('/sources'), res => {
+        expect(res.statusCode).toBe(301)
+        expect(res.headers.location).toBe('/sources/')
+        done()
+      })
+    })
+
+    it('registers requested files to dep resolver', done => {
+      http.get(reqTo('/sources/index.scss'), () => {
+        const absPath = path.resolve(base, 'sources/index.scss')
+        const content = fs.readFileSync(absPath, 'utf8')
+        td.verify(mockResolver.register(absPath, content))
+        done()
+      })
     })
   })
 
-  it('registers requested files to dep resolver', done => {
-    http.get(reqTo('/sources/index.scss'), () => {
-      const absPath = path.resolve(base, 'sources/index.scss')
-      const content = fs.readFileSync(absPath, 'utf8')
-      td.verify(mockResolver.register(absPath, content))
-      done()
+  describe('with base path', () => {
+    beforeAll(done => {
+      bs = create(config, {
+        port: 51234,
+        open: false,
+        logLevel: 'silent'
+      }, mockResolver, '/path/to/base')
+
+      bs.emitter.on('init', done)
+    })
+
+    afterAll(() => {
+      bs.exit()
+    })
+
+    it('allows to set base path of assets', done => {
+      http.get(reqTo('/path/to/base/sources/index.html'), waitForData((res, data) => {
+        expect(res.statusCode).toBe(200)
+        expectDataToBeFile(data, 'sources/index.html')
+        done()
+      }))
+    })
+
+    it('returns not found message if the req does not follow the base path', done => {
+      http.get(reqTo('/sources/index.html'), res => {
+        expect(res.statusCode).toBe(404)
+        done()
+      })
     })
   })
 })

--- a/test/specs/externals/browser-sync.spec.js
+++ b/test/specs/externals/browser-sync.spec.js
@@ -120,5 +120,13 @@ describe('Using browsersync', () => {
         done()
       })
     })
+
+    it('redirects if it requests to the root of base path', done => {
+      http.get(reqTo('/path/to/base'), res => {
+        expect(res.statusCode).toBe(301)
+        expect(res.headers.location).toBe('/path/to/base/')
+        done()
+      })
+    })
   })
 })

--- a/test/specs/util.spec.js
+++ b/test/specs/util.spec.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const util = require('../../lib/util')
+
+describe('Util', () => {
+  describe('dropWhile', () => {
+    const isZero = item => item === 0
+
+    it('works', () => {
+      expect(util.dropWhile([0, 0, 1, 2, 0, 3], isZero)).toEqual([1, 2, 0, 3])
+    })
+
+    it('keeps original if not matched', () => {
+      const list = [1, 2, 3, 4]
+      expect(util.dropWhile(list, isZero)).toEqual(list)
+    })
+
+    it('drops all if matched all', () => {
+      expect(util.dropWhile([0, 0, 0], isZero)).toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
Fix #32 

This PR adds a `--base-path` option for `dev` command. The command allows us to set the base path of the assets.

```bash
$ houl dev --base-path test
# -> http://localhost:3000/test/index.html returns index.html in the root input directory
```