### PR TITLE
Allow to specify an array type for exclude option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Key            | Description
 -------------- | --------------------------------------------------------
 input          | Path to source directory
 output         | Path to destination directory
-exclude        | Glob pattern of files that will be ignored from input
+exclude        | Glob pattern(s) of files that will be ignored from input
 taskFile       | Path to task file that is described in the later section
 preset         | Preset package name or an object that specify a preset
 preset.name    | Preset package name
@@ -100,7 +100,7 @@ Key       | Description
 --------- | -----------------------------------------------------------------------------------------------------------
 task      | Task name that will apply transformations
 outputExt | Extension of output files. If omitted, it is same as input files' extensions.
-exclude   | Glob pattern of files that will not be applied the rule
+exclude   | Glob pattern(s) of files that will not be applied the rule
 progeny   | Specify [progeny configs](https://github.com/es128/progeny#configuration) for the corresponding file format
 options   | Options for the corresponding task that is passed to the 2nd argument of the task
 
@@ -152,7 +152,7 @@ Full example of config file:
 {
   "input": "./src",
   "output": "./dist",
-  "exclude": "**/_*",
+  "exclude": ["**/_*", "**/private/**"],
   "taskFile": "./houl.task.js",
   "preset": "houl-preset-foo",
   "rules": {

--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -26,7 +26,10 @@ module.exports = class Config {
     }
 
     // `exclude` option excludes matched files from `input`
-    this.exclude = config.exclude
+    this.exclude = config.exclude || []
+    if (typeof this.exclude === 'string') {
+      this.exclude = [this.exclude]
+    }
 
     // Resolve and merge rules by traversing preset
     this.rules = this._resolveRules(config.rules || {}, tasks, preset)
@@ -45,9 +48,9 @@ module.exports = class Config {
       path.join(this.input, '**/*')
     ]
 
-    if (this.exclude) {
-      res.push('!' + this.exclude)
-    }
+    this.exclude.forEach(exclude => {
+      res.push('!' + exclude)
+    })
 
     return res
   }
@@ -56,15 +59,13 @@ module.exports = class Config {
    * Check the pathname matches `exclude` pattern or not.
    */
   isExclude (pathname) {
-    if (!this.exclude) {
-      return false
-    }
-
     if (path.isAbsolute(pathname)) {
       pathname = path.relative(this.input, pathname)
     }
 
-    return minimatch(pathname, this.exclude)
+    return this.exclude.reduce((acc, exclude) => {
+      return acc || minimatch(pathname, exclude)
+    }, false)
   }
 
   findRuleByInput (inputName) {

--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -72,10 +72,7 @@ module.exports = class Config {
     const ext = path.extname(inputName).slice(1)
     const rule = this.rules[ext]
 
-    if (
-      !rule ||
-      rule.exclude && minimatch(inputName, rule.exclude)
-    ) {
+    if (!rule || rule.isExclude(inputName)) {
       return null
     }
 
@@ -102,7 +99,7 @@ module.exports = class Config {
 
       if (!exists(inputName)) continue
 
-      if (rule.exclude && minimatch(inputName, rule.exclude)) {
+      if (rule.isExclude(inputName)) {
         continue
       }
 

--- a/lib/models/rule.js
+++ b/lib/models/rule.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('assert')
+const minimatch = require('minimatch')
 const util = require('../util')
 const createTask = require('./task')
 
@@ -11,7 +12,7 @@ const emptyRule = new class EmptyRule {
     this.task = util.identity
     this.inputExt = null
     this.outputExt = null
-    this.exclude = null
+    this.exclude = []
     this.progeny = undefined
   }
 
@@ -21,6 +22,10 @@ const emptyRule = new class EmptyRule {
 
   getOutputPath (inputPath) {
     return inputPath
+  }
+
+  isExclude () {
+    return false
   }
 }
 
@@ -35,7 +40,11 @@ module.exports = class Rule {
 
     this.inputExt = inputExt
     this.outputExt = rule.outputExt || this.inputExt
-    this.exclude = rule.exclude
+
+    this.exclude = rule.exclude || []
+    if (typeof this.exclude === 'string') {
+      this.exclude = [this.exclude]
+    }
 
     this.progeny = rule.progeny
     if (this.progeny) {
@@ -51,6 +60,12 @@ module.exports = class Rule {
   getOutputPath (inputPath) {
     const extRE = new RegExp(`\\.${this.inputExt}$`, 'i')
     return inputPath.replace(extRE, `.${this.outputExt}`)
+  }
+
+  isExclude (inputPath) {
+    return this.exclude.reduce((acc, exclude) => {
+      return acc || minimatch(inputPath, exclude)
+    }, false)
   }
 
   static get empty () {

--- a/test/specs/models/config.spec.js
+++ b/test/specs/models/config.spec.js
@@ -20,7 +20,8 @@ describe('Config model', () => {
       exclude: '**/_*'
     }, {})
 
-    expect(c.exclude).toBePath('**/_*')
+    expect(c.exclude.length).toBe(1)
+    expect(c.exclude[0]).toBePath('**/_*')
   })
 
   it('creates vinyl input', () => {
@@ -45,8 +46,24 @@ describe('Config model', () => {
     expect(c.vinylInput[1]).toBePath('!**/_*')
   })
 
+  it('includes array formed `exclude` pattern into vinyl input', () => {
+    const c = new Config({
+      input: 'src',
+      exclude: ['**/_*', '**/.DS_Store']
+    }, {}, {
+      base: '/path/to/'
+    })
+    const input = c.vinylInput
+    expect(input.length).toBe(3)
+    expect(input[0]).toBePath('/path/to/src/**/*')
+    expect(input[1]).toBePath('!**/_*')
+    expect(input[2]).toBePath('!**/.DS_Store')
+  })
+
   it('isExclude always returns false if `exclude` is empty', () => {
-    const c = new Config({}, {})
+    const c = new Config({
+      input: 'src'
+    }, {})
 
     expect(c.isExclude('/path/to/foo.css')).toBe(false)
     expect(c.isExclude('')).toBe(false)

--- a/test/specs/models/rule.spec.js
+++ b/test/specs/models/rule.spec.js
@@ -20,11 +20,22 @@ describe('Rule model', () => {
     expect(r.task()).toBe('foo')
     expect(r.inputExt).toBe('scss')
     expect(r.outputExt).toBe('css')
-    expect(r.exclude).toBe('**/vendor/**')
+    expect(r.exclude).toEqual(['**/vendor/**'])
     expect(r.progeny).toEqual({
       extension: 'scss',
       rootPath: 'path/to/root'
     })
+  })
+
+  it('accepts array formed exclude', () => {
+    const r = new Rule({
+      task: 'foo',
+      exclude: ['**/vendor/**', '**/.DS_Store']
+    }, 'js', {
+      foo: () => 'foo'
+    })
+
+    expect(r.exclude).toEqual(['**/vendor/**', '**/.DS_Store'])
   })
 
   it('deals with string format', () => {
@@ -77,6 +88,19 @@ describe('Rule model', () => {
     })
 
     expect(r.getOutputPath('path/to/test.scss')).toBe('path/to/test.css')
+  })
+
+  it('checks whether the given path is excluded or not', () => {
+    const r = new Rule({
+      task: 'foo',
+      exclude: ['**/vendor/**', '**/_*']
+    }, 'js', {
+      foo: () => 'foo'
+    })
+
+    expect(r.isExclude('src/js/vendor/index.js')).toBe(true)
+    expect(r.isExclude('src/js/_hidden.js')).toBe(true)
+    expect(r.isExclude('src/js/index.js')).toBe(false)
   })
 
   describe('Empty rule', () => {

--- a/test/specs/models/rule.spec.js
+++ b/test/specs/models/rule.spec.js
@@ -118,6 +118,10 @@ describe('Rule model', () => {
       expect(empty.getOutputPath('/path/to/test.js')).toBe('/path/to/test.js')
     })
 
+    it('always treats that the input path is not excluded', () => {
+      expect(empty.isExclude('/path/to/something')).toBe(false)
+    })
+
     it('has the task that does nothing', () => {
       expect(empty.task('foobar')).toBe('foobar')
     })


### PR DESCRIPTION
We can use an array value for `exclude` option as well after merging this PR. Both `exclude` options that under the root and the `rules` can be an array.

```json
{
  "input": "src",
  "output": "dist",
  "exclude": ["**/private/**", "**/_*"],
  "rules": {
    "js": {
      "task": "script",
      "exclude": ["**/vendor/**"]
    }
  }
}
```