### PR TITLE
Add watch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,26 +16,33 @@ $ yarn global add houl
 
 ## Command
 
-Houl provides two commands - `build` and `dev`.
+Houl provides two commands - `build`, `dev` and `watch`.
 
 ```bash
 $ houl build
 $ houl dev
+$ houl watch
 ```
 
-`houl build` transform/copy all source files into destination directory that is written in a config file while `houl dev` starts a dev server (powered by [BrowserSync](https://browsersync.io/)). The dev server dynamically transform a source file when a request is recieved, then you will not suffer the perfomance problem that depends on the size of static site.
+`houl build` transform/copy all source files into destination directory that is written in a config file.
+
+`houl dev` starts a dev server (powered by [BrowserSync](https://browsersync.io/)). The dev server dynamically transform a source file when a request is recieved, then you will not suffer the perfomance problem that depends on the size of static site.
+
+`houl watch` is similar with `houl dev` but it does not start dev server. It watches and builds updated files incrementally. This command is useful in a project that requires some additional processing for asset files such as the asset pipeline of Ruby on Rails.
 
 Houl automatically loads `houl.config.js` or `houl.config.json` as a config file but you can use `--config` (shorthand `-c`) option if you prefer to load other config file.
 
 ```bash
 $ houl build -c config.js
 $ houl dev -c config.js
+$ houl watch -c config.js
 ```
 
-If you want to include dot files (e.g. `.htaccess`) in input, set `--dot` flag with build command.
+If you want to include dot files (e.g. `.htaccess`) in input, set `--dot` flag with `build` and `watch` command.
 
 ```bash
 $ houl build --dot
+$ houl watch --dot
 ```
 
 ### Enable build cache
@@ -44,6 +51,7 @@ You may want to cache each build file and process only updated files in the next
 
 ```bash
 $ houl build --cache .houlcache
+$ houl watch --cache .houlcache
 ```
 
 Note that the file name that is specified with `--cache` option (`.houlcache` in the above example) is a cache file to check updated files since the previous build. You need to specify the same file on every build to make sure to work the cache system correctly.

--- a/bin/houl.js
+++ b/bin/houl.js
@@ -5,6 +5,7 @@ require('yargs') // eslint-disable-line
   .usage('Usage: $0 <command> [options]')
   .command('build', 'Build your project with config and tasks', require('../lib/cli/build'))
   .command('dev', 'Start development server', require('../lib/cli/dev'))
+  .command('watch', 'Watch the input directory and build updated files incrementally', require('../lib/cli/watch'))
   .demandCommand(1)
   .help('h')
   .alias('h', 'help')

--- a/lib/cli/dev.js
+++ b/lib/cli/dev.js
@@ -42,11 +42,11 @@ exports.handler = argv => {
     open: !argv._debug // Internal
   }, resolver, basePath)
 
-  createWatcher(config, resolver, files => {
+  const watcher = createWatcher(config, resolver, files => {
     bs.reload(files.map(resolveOutput))
   })
 
-  return bs
+  return { bs, watcher }
 
   function resolveOutput (inputName) {
     const rule = config.findRuleByInput(inputName)

--- a/lib/cli/dev.js
+++ b/lib/cli/dev.js
@@ -42,7 +42,7 @@ exports.handler = argv => {
     open: !argv._debug // Internal
   }, resolver, basePath)
 
-  createWatcher(config, resolver, { initial: false }, files => {
+  createWatcher(config, resolver, files => {
     bs.reload(files.map(resolveOutput))
   })
 

--- a/lib/cli/watch.js
+++ b/lib/cli/watch.js
@@ -1,0 +1,72 @@
+'use strict'
+
+const assert = require('assert')
+const vfs = require('vinyl-fs')
+const hashSum = require('hash-sum')
+const loadConfig = require('../config').loadConfig
+const findConfig = require('../config').findConfig
+const Cache = require('../cache')
+const DepResolver = require('../dep-resolver')
+const taskStream = require('../task-stream')
+const cacheStream = require('../cache-stream')
+const createWatcher = require('../externals/watcher')
+const util = require('../util')
+
+exports.builder = {
+  config: {
+    alias: 'c',
+    describe: 'Path to a houl config file'
+  },
+  cache: {
+    describe: 'Path to a houl cache file'
+  },
+  dot: {
+    describe: 'Include dot files in output',
+    boolean: true
+  }
+}
+
+exports.handler = argv => {
+  const configPath = argv.config || findConfig(process.cwd())
+  assert(configPath, 'Config file is not found')
+  const config = loadConfig(configPath)
+
+  const cache = new Cache(hashSum)
+  const depResolver = DepResolver.create(config)
+
+  // Restore cache data
+  if (argv.cache) {
+    const cacheData = util.readFileSync(argv.cache)
+
+    if (cacheData) {
+      const json = JSON.parse(cacheData)
+
+      // Restore cache data
+      cache.deserialize(json.cache)
+
+      // Restore deps data
+      depResolver.deserialize(json.deps)
+    }
+  }
+
+  stream(config.vinylInput)
+  createWatcher(config, depResolver, files => {
+    stream(files)
+  })
+
+  function stream(sources) {
+    vfs.src(sources, { nodir: true, dot: argv.dot, base: config.input })
+      .pipe(cacheStream(cache, depResolver, util.readFileSync))
+      .pipe(taskStream(config))
+      .pipe(vfs.dest(config.output))
+      .on('finish', () => {
+        if (!argv.cache) return
+
+        const serialized = JSON.stringify({
+          cache: cache.serialize(),
+          deps: depResolver.serialize()
+        })
+        util.writeFileSync(argv.cache, serialized)
+      })
+  }
+}

--- a/lib/cli/watch.js
+++ b/lib/cli/watch.js
@@ -26,7 +26,8 @@ exports.builder = {
   }
 }
 
-exports.handler = argv => {
+// The callback `cb` is for testing purpose
+exports.handler = (argv, cb) => {
   const configPath = argv.config || findConfig(process.cwd())
   assert(configPath, 'Config file is not found')
   const config = loadConfig(configPath)
@@ -49,13 +50,13 @@ exports.handler = argv => {
     }
   }
 
-  stream(config.vinylInput)
-  createWatcher(config, depResolver, files => {
-    stream(files)
+  stream(config.vinylInput).on('finish', cb)
+  return createWatcher(config, depResolver, files => {
+    stream(files).on('finish', cb)
   })
 
   function stream(sources) {
-    vfs.src(sources, { nodir: true, dot: argv.dot, base: config.input })
+    return vfs.src(sources, { nodir: true, dot: argv.dot, base: config.input })
       .pipe(cacheStream(cache, depResolver, util.readFileSync))
       .pipe(taskStream(config))
       .pipe(vfs.dest(config.output))

--- a/lib/externals/watcher.js
+++ b/lib/externals/watcher.js
@@ -3,9 +3,9 @@
 const path = require('path')
 const chokidar = require('chokidar')
 
-module.exports = function createWatcher (config, depResolver, options, cb) {
+module.exports = function createWatcher (config, depResolver, cb) {
   return chokidar.watch(config.input, {
-    ignoreInitial: !options.initial,
+    ignoreInitial: true,
     cwd: config.input
   }).on('change', pathname => {
     const fullPath = path.resolve(config.input, pathname)

--- a/test/e2e/build.spec.js
+++ b/test/e2e/build.spec.js
@@ -13,13 +13,9 @@ describe('Build CLI', () => {
 
   let revert
 
-  beforeEach(done => {
-    removeDist(() => {
-      fse.remove(cache, err => {
-        if (err) throw err
-        done()
-      })
-    })
+  beforeEach(() => {
+    removeDist()
+    fse.removeSync(cache)
 
     process.env.NODE_ENV = null
   })
@@ -50,14 +46,11 @@ describe('Build CLI', () => {
 
   it('should not build cached files', done => {
     build({ config, cache }).on('finish', () => {
-      removeDist(() => {
-        updateSrc(_revert => {
-          revert = _revert
-          build({ config, cache }).on('finish', () => {
-            compare('cache')
-            done()
-          })
-        })
+      removeDist()
+      revert = updateSrc()
+      build({ config, cache }).on('finish', () => {
+        compare('cache')
+        done()
       })
     })
   })

--- a/test/e2e/dev.spec.js
+++ b/test/e2e/dev.spec.js
@@ -20,14 +20,17 @@ function assertData (data, file, type) {
 describe('Dev CLI', () => {
   const config = 'test/fixtures/e2e/houl.config.json'
 
-  let bs
+  let bs, watcher
   function run (options, cb) {
-    bs = dev({
+    const res = dev({
       config: options.config,
       port: options.port || 3000,
       'base-path': options['base-path'] || '/',
       _debug: true
     })
+
+    bs = res.bs
+    watcher = res.watcher
 
     bs.emitter.on('init', () => cb(bs))
 
@@ -58,9 +61,11 @@ describe('Dev CLI', () => {
 
   afterEach(() => {
     if (bs) bs.exit()
+    if (watcher) watcher.close()
     if (revert) revert()
 
     bs = null
+    watcher = null
     revert = null
   })
 

--- a/test/e2e/watch.spec.js
+++ b/test/e2e/watch.spec.js
@@ -1,0 +1,83 @@
+'use strict'
+
+const fse = require('fs-extra')
+const watch = require('../../lib/cli/watch').handler
+const e2eHelpers = require('../helpers/e2e')
+const updateSrc = e2eHelpers.updateSrc
+const removeDist = e2eHelpers.removeDist
+const compare = e2eHelpers.compare
+
+describe('Build CLI', () => {
+  const config = 'test/fixtures/e2e/houl.config.json'
+  const cache = 'test/fixtures/e2e/.cache.json'
+
+  let revert, watcher
+
+  function run (options, cbs) {
+    watcher = watch(options, cbs)
+  }
+
+  function update () {
+    revert = updateSrc()
+  }
+
+  beforeEach(() => {
+    removeDist()
+    fse.removeSync(cache)
+  })
+
+  afterEach(() => {
+    if (watcher) {
+      watcher.close()
+      watcher = null
+    }
+
+    if (revert) {
+      revert()
+      revert = null
+    }
+  })
+
+  it('should build all input files initially', done => {
+    run({ config }, observe([
+      () => {
+        compare('dev')
+        update()
+      },
+      () => {
+        compare('updated')
+        done()
+      }
+    ]))
+  })
+
+  it('should build only updated files', done => {
+    run({ config }, observe([
+      () => {
+        removeDist()
+        update()
+      },
+      () => {
+        compare('cache')
+        done()
+      }
+    ]))
+  })
+})
+
+function observe (cbs) {
+  const throttle = 10
+  let timer = null
+  let count = -1
+
+  // Delay a watcher callback because a watcher may batch
+  // multiple call for multiple file updates
+  return () => {
+    clearTimeout(timer)
+
+    timer = setTimeout(() => {
+      count += 1
+      cbs[count]()
+    }, throttle)
+  }
+}

--- a/test/e2e/watch.spec.js
+++ b/test/e2e/watch.spec.js
@@ -14,6 +14,9 @@ describe('Build CLI', () => {
   let revert, watcher
 
   function run (options, cbs) {
+    if (watcher) {
+      watcher.close()
+    }
     watcher = watch(options, cbs)
   }
 
@@ -60,6 +63,26 @@ describe('Build CLI', () => {
       () => {
         compare('cache')
         done()
+      }
+    ]))
+  })
+
+  it('should build only updated files even if after restart the command', done => {
+    run({ config, cache }, observe([
+      () => {
+        // Equivalent with exiting watch command
+        watcher.close()
+
+        removeDist()
+        update()
+
+        // Equivalent with restart watch command
+        run({ config, cache }, observe([
+          () => {
+            compare('cache')
+            done()
+          }
+        ]))
       }
     ]))
   })

--- a/test/expected/updated/css/index.css
+++ b/test/expected/updated/css/index.css
@@ -1,0 +1,5 @@
+h1 {
+  color: red;
+}
+
+/* In dev mode */

--- a/test/expected/updated/index.html
+++ b/test/expected/updated/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Example</title>
+    <link rel="stylesheet" href="css/index.css">
+  </head>
+  <body>
+    <h1>Example title</h1>
+    <script src="js/vendor/lib.js"></script>
+    <script src="js/index.js"></script>
+  </body>
+</html>

--- a/test/expected/updated/js/index.js
+++ b/test/expected/updated/js/index.js
@@ -1,0 +1,4 @@
+var message = 'Updated message'
+console.log(message)
+
+/* In dev mode */

--- a/test/expected/updated/js/vendor/lib.js
+++ b/test/expected/updated/js/vendor/lib.js
@@ -1,0 +1,4 @@
+const foo = 'Some libs'
+window.Lib = {
+  foo
+}

--- a/test/helpers/e2e.js
+++ b/test/helpers/e2e.js
@@ -3,35 +3,22 @@
 const path = require('path')
 const fse = require('fs-extra')
 
-exports.updateSrc = function updateSrc (cb) {
+exports.updateSrc = function updateSrc () {
   const original = path.resolve(__dirname, '../fixtures/e2e/src')
   const temp = path.resolve(__dirname, '../fixtures/e2e/.tmp')
   const updated = path.resolve(__dirname, '../fixtures/e2e/updated-src')
 
-  function handleError (fn) {
-    return err => {
-      if (err) throw err
-      fn()
-    }
+  fse.copySync(original, temp)
+  fse.copySync(updated, original)
+
+  return () => {
+    fse.copySync(temp, original)
+    fse.removeSync(temp)
   }
-
-  fse.copy(original, temp, handleError(() => {
-    fse.copy(updated, original, handleError(() => {
-      const revert = () => {
-        fse.copySync(temp, original)
-        fse.removeSync(temp)
-      }
-
-      cb(revert)
-    }))
-  }))
 }
 
-exports.removeDist = function removeDist (cb) {
-  fse.remove(path.resolve(__dirname, '../fixtures/e2e/dist'), err => {
-    if (err) throw err
-    cb()
-  })
+exports.removeDist = function removeDist () {
+  fse.removeSync(path.resolve(__dirname, '../fixtures/e2e/dist'))
 }
 
 exports.compare = function compare (type) {


### PR DESCRIPTION
`watch` command is similar with `dev` command but it does not start dev server. It will build updated files incrementally instead.

Example:
```bash
$ houl watch -c houl.config.js
```

This command is useful in a project that requires some additional processing for asset files such as asset pipeline of Ruby on Rails.

The `watch` command can receive `--config`, `--cache` and `--dot` options similar to `build` command. I don't include `--production` flag in `watch` command intentionally since I have no idea of use case for that.