### PR TITLE
feat: print log while executing build, dev or watch command

### DIFF
--- a/lib/cli/build.js
+++ b/lib/cli/build.js
@@ -86,6 +86,9 @@ exports.handler = (argv, debug) => {
 
   // Transform inputs with rules
   stream = stream.pipe(taskStream(config))
+    // This line does not work yet.
+    // We must patch .pipe method and handle
+    // all error events for each stream.
     .on('error', err => { logger.error(err) })
 
   // Output

--- a/lib/cli/build.js
+++ b/lib/cli/build.js
@@ -7,6 +7,7 @@ const loadConfig = require('../config').loadConfig
 const findConfig = require('../config').findConfig
 const Cache = require('../cache')
 const DepResolver = require('../dep-resolver')
+const BuildLogger = require('../loggers/build-logger')
 const taskStream = require('../task-stream')
 const cacheStream = require('../cache-stream')
 const util = require('../util')
@@ -32,7 +33,9 @@ exports.builder = {
   }
 }
 
-exports.handler = argv => {
+exports.handler = (argv, debug) => {
+  debug = debug || {}
+
   if (argv.production) {
     process.env.NODE_ENV = 'production'
   }
@@ -42,6 +45,12 @@ exports.handler = argv => {
   const config = loadConfig(configPath).extend({
     filter: argv.filter
   })
+
+  // Logger
+  const logger = new BuildLogger(config, {
+    console: debug.console
+  })
+  logger.start()
 
   // Process all files in input directory
   let stream = vfs.src(config.vinylInput, { nodir: true, dot: argv.dot })
@@ -77,7 +86,9 @@ exports.handler = argv => {
 
   // Transform inputs with rules
   stream = stream.pipe(taskStream(config))
+    .on('error', err => { logger.error(err) })
 
   // Output
   return stream.pipe(vfs.dest(config.output))
+    .on('finish', () => { logger.finish() })
 }

--- a/lib/cli/dev.js
+++ b/lib/cli/dev.js
@@ -1,11 +1,13 @@
 'use strict'
 
 const assert = require('assert')
+const url = require('url')
 const loadConfig = require('../config').loadConfig
 const findConfig = require('../config').findConfig
 const DepResolver = require('../dep-resolver')
 const create = require('../externals/browser-sync')
 const createWatcher = require('../externals/watcher')
+const DevLogger = require('../loggers/dev-logger')
 
 exports.builder = {
   config: {
@@ -24,12 +26,19 @@ exports.builder = {
   }
 }
 
-exports.handler = argv => {
+exports.handler = (argv, debug) => {
+  debug = debug || {}
+
   const configPath = argv.config || findConfig(process.cwd())
   assert(configPath, 'Config file is not found')
   const config = loadConfig(configPath)
 
   assert(!Number.isNaN(argv.port), '--port should be a number')
+
+  // Logger
+  const logger = new DevLogger(config, {
+    console: debug.console
+  })
 
   const resolver = DepResolver.create(config)
 
@@ -38,11 +47,17 @@ exports.handler = argv => {
   const bs = create(config, {
     port: argv.port,
     startPath: basePath,
-    logLevel: argv._debug ? 'silent' : 'info', // Internal
+    logLevel: 'silent',
+    middleware: logMiddleware,
     open: !argv._debug // Internal
   }, resolver, basePath)
 
-  const watcher = createWatcher(config, resolver, files => {
+  bs.emitter.on('init', () => {
+    logger.startDevServer(argv.port)
+  })
+
+  const watcher = createWatcher(config, resolver, (files, origin) => {
+    logger.updateFile(origin)
     bs.reload(files.map(resolveOutput))
   })
 
@@ -56,5 +71,11 @@ exports.handler = argv => {
     } else {
       return rule.getOutputPath(inputName)
     }
+  }
+
+  function logMiddleware (req, res, next) {
+    const parsedPath = url.parse(req.url).pathname
+    logger.getFile(parsedPath)
+    next()
   }
 }

--- a/lib/cli/watch.js
+++ b/lib/cli/watch.js
@@ -10,6 +10,7 @@ const DepResolver = require('../dep-resolver')
 const taskStream = require('../task-stream')
 const cacheStream = require('../cache-stream')
 const createWatcher = require('../externals/watcher')
+const WatchLogger = require('../loggers/watch-logger')
 const util = require('../util')
 
 exports.builder = {
@@ -26,9 +27,8 @@ exports.builder = {
   }
 }
 
-// The callback `cb` is for testing purpose
-exports.handler = (argv, cb) => {
-  cb = cb || util.noop
+exports.handler = (argv, debug) => {
+  debug = debug || { cb: util.noop }
 
   const configPath = argv.config || findConfig(process.cwd())
   assert(configPath, 'Config file is not found')
@@ -52,9 +52,21 @@ exports.handler = (argv, cb) => {
     }
   }
 
-  stream(config.vinylInput).on('finish', cb)
-  return createWatcher(config, depResolver, files => {
-    stream(files).on('finish', cb)
+  // Logger
+  const logger = new WatchLogger(config, {
+    console: debug.console || console
+  })
+
+  stream(config.vinylInput).on('finish', debug.cb)
+  return createWatcher(config, depResolver, (files, origin) => {
+    logger.updateFile(origin)
+    stream(files)
+      .on('data', file => {
+        logger.writeFile(file.path)
+      })
+      .on('finish', debug.cb)
+  }).on('ready', () => {
+    logger.startWatching()
   })
 
   function stream(sources) {

--- a/lib/color.js
+++ b/lib/color.js
@@ -2,6 +2,7 @@
 
 const GREEN = '\u001b[32m'
 const YELLOW = '\u001b[33m'
+const CYAN = '\u001b[36m'
 
 const RESET = '\u001b[0m'
 
@@ -13,5 +14,10 @@ function yellow(str) {
   return YELLOW + str + RESET
 }
 
+function cyan(str) {
+  return CYAN + str + RESET
+}
+
 exports.green = green
 exports.yellow = yellow
+exports.cyan = cyan

--- a/lib/color.js
+++ b/lib/color.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const GREEN = '\u001b[32m'
+const YELLOW = '\u001b[33m'
+
+const RESET = '\u001b[0m'
+
+function green(str) {
+  return GREEN + str + RESET
+}
+
+function yellow(str) {
+  return YELLOW + str + RESET
+}
+
+exports.green = green
+exports.yellow = yellow

--- a/lib/externals/watcher.js
+++ b/lib/externals/watcher.js
@@ -16,6 +16,6 @@ module.exports = function createWatcher (config, depResolver, cb) {
     // Resolve depended files
     const dirtyFiles = [fullPath].concat(depResolver.getInDeps(fullPath))
 
-    cb(dirtyFiles)
+    cb(dirtyFiles, fullPath)
   })
 }

--- a/lib/loggers/build-logger.js
+++ b/lib/loggers/build-logger.js
@@ -1,0 +1,64 @@
+'use strict'
+
+const assert = require('assert')
+const path = require('path')
+const util = require('../util')
+
+class BuildLogger {
+  constructor (config, options) {
+    options = options || {}
+
+    this.errorCount = 0
+    this.config = config
+    this.console = options.console || console
+    this.now = options.now || Date.now
+    this.startedTime = null
+  }
+
+  start () {
+    const input = normalize(this.config.base, this.config.input)
+    const output = normalize(this.config.base, this.config.output)
+
+    this.startedTime = this.now()
+
+    this.console.log(`Building ${input} -> ${output}`)
+  }
+
+  error (err) {
+    assert(this.startedTime !== null)
+
+    this.console.error(err.message)
+    this.errorCount += 1
+  }
+
+  finish () {
+    assert(this.startedTime !== null)
+
+    if (this.errorCount > 0) {
+      this.console.log(`Finished with ${this.errorCount} error(s)`)
+      return
+    }
+
+    const time = this.now() - this.startedTime
+    this.console.log(`Finished in ${prittyTime(time)}`)
+  }
+}
+module.exports = BuildLogger
+
+function normalize (base, pathname) {
+  return util.normalizePath(path.relative(base, pathname))
+}
+
+function prittyTime (msec) {
+  if (msec < 1000 * 0.1) {
+    return trunc(msec) + 'ms'
+  } else if (msec < 1000 * 1000 * 0.1) {
+    return trunc(msec / 1000) + 's'
+  } else {
+    return trunc(msec / (1000 * 1000)) + 'm'
+  }
+}
+
+function trunc (n) {
+  return Math.floor(n * 100) / 100
+}

--- a/lib/loggers/dev-logger.js
+++ b/lib/loggers/dev-logger.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const path = require('path')
+const color = require('../color')
+
+class DevLogger {
+  constructor (config, options) {
+    options = options || {}
+
+    this.config = config
+    this.console = options.console || console
+
+    this.modPath = (pathName) => {
+      return '/' + path.relative(this.config.input, pathName)
+    }
+  }
+
+  startDevServer (port) {
+    this.console.log(`Houl dev server is running at http://localhost:${port}`)
+  }
+
+  updateFile (source) {
+    this._write(color.yellow('UPDATED'), this.modPath(source))
+  }
+
+  getFile (pathname) {
+    this._write(color.green('GET'), pathname)
+  }
+
+  _write (label, text) {
+    this.console.log(label + ' ' + text)
+  }
+}
+module.exports = DevLogger

--- a/lib/loggers/watch-logger.js
+++ b/lib/loggers/watch-logger.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const path = require('path')
+const color = require('../color')
+
+class WatchLogger {
+  constructor (config, options) {
+    this.config = config
+    this.console = options.console || console
+
+    this.modPath = (pathName) => {
+      return '/' + path.relative(this.config.base, pathName)
+    }
+  }
+
+  startWatching () {
+    const source = path.relative(this.config.base, this.config.input) + '/'
+    this.console.log(`Houl is watching the source directory: ${source}`)
+  }
+
+  updateFile (source) {
+    this._write(color.yellow('UPDATED'), this.modPath(source))
+  }
+
+  writeFile (dest) {
+    this._write(color.cyan('WROTE'), this.modPath(dest))
+  }
+
+  _write (label, text) {
+    this.console.log(label + ' ' + text)
+  }
+}
+module.exports = WatchLogger

--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -7,6 +7,7 @@ const util = require('../util')
 
 module.exports = class Config {
   constructor (config) {
+    this.base = config.base
     this.input = config.input
     this.output = config.output
     this.exclude = config.exclude || []
@@ -100,6 +101,8 @@ module.exports = class Config {
     const resolve = makeResolve(options.base || '')
 
     return new Config({
+      base: options.base,
+
       // Resolve input/output paths
       input: typeof config.input === 'string' && resolve(config.input),
       output: typeof config.output === 'string' && resolve(config.output),

--- a/lib/task-stream.js
+++ b/lib/task-stream.js
@@ -38,7 +38,7 @@ class TaskStream extends Duplex {
           file.extname = '.' + rule.outputExt
           this.push(file)
         })
-        .on('error', file => this.emit('error', file))
+        .on('error', err => this.emit('error', err))
 
       // Register the source stream to use later.
       map.set(rule, { input, output })

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const path = require('path')
 const fs = require('fs')
 
 exports.noop = () => {}
@@ -33,6 +34,10 @@ exports.mapValues = (val, fn) => {
 
 exports.isLocalPath = pathname => {
   return /^[\.\/]/.test(pathname)
+}
+
+exports.normalizePath = pathname => {
+  return pathname.split(path.sep).join('/')
 }
 
 exports.readFileSync = fileName => {

--- a/test/e2e/dev.spec.js
+++ b/test/e2e/dev.spec.js
@@ -3,6 +3,7 @@
 const http = require('http')
 const fse = require('fs-extra')
 const path = require('path')
+const td = require('testdouble')
 const dev = require('../../lib/cli/dev').handler
 const waitForData = require('../helpers').waitForData
 
@@ -22,11 +23,18 @@ describe('Dev CLI', () => {
 
   let bs, watcher
   function run (options, cb) {
+    const console = {
+      log: td.function(),
+      error: td.function()
+    }
+
     const res = dev({
       config: options.config,
       port: options.port || 3000,
       'base-path': options['base-path'] || '/',
       _debug: true
+    }, {
+      console
     })
 
     bs = res.bs

--- a/test/e2e/watch.spec.js
+++ b/test/e2e/watch.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const fse = require('fs-extra')
+const td = require('testdouble')
 const watch = require('../../lib/cli/watch').handler
 const e2eHelpers = require('../helpers/e2e')
 const updateSrc = e2eHelpers.updateSrc
@@ -13,11 +14,15 @@ describe('Build CLI', () => {
 
   let revert, watcher
 
-  function run (options, cbs) {
+  function run (options, cb) {
     if (watcher) {
       watcher.close()
     }
-    watcher = watch(options, cbs)
+    const console = {
+      log: td.function(),
+      error: td.function()
+    }
+    watcher = watch(options, { cb, console })
   }
 
   function update () {

--- a/test/specs/loggers/build-logger.spec.js
+++ b/test/specs/loggers/build-logger.spec.js
@@ -1,0 +1,67 @@
+'use strict'
+
+const td = require('testdouble')
+const BuildLogger = require('../../../lib/loggers/build-logger')
+
+describe('Build Logger', () => {
+  it('should log that a build is started', () => {
+    const console = { log: td.function() }
+    const logger = new BuildLogger({
+      base: '/path/to/base',
+      input: '/path/to/base/src',
+      output: '/path/to/base/dist'
+    }, {
+      console
+    })
+
+    logger.start()
+
+    td.verify(console.log('Building src -> dist'))
+  })
+
+  it('should log that a build is finished', () => {
+    const console = { log: td.function() }
+    const now = td.function()
+
+    td.when(now()).thenReturn(0, 12345)
+
+    const logger = new BuildLogger({
+      base: '/base',
+      input: '/base/to/src',
+      output: '/base/to/dist'
+    }, {
+      console,
+      now
+    })
+
+    logger.start()
+    td.verify(console.log('Building to/src -> to/dist'))
+
+    logger.finish()
+    td.verify(console.log('Finished in 12.34s'))
+  })
+
+  it('should log errors', () => {
+    const console = {
+      log: td.function(),
+      error: td.function()
+    }
+
+    const logger = new BuildLogger({
+      base: '/path',
+      input: '/path/src',
+      output: '/path/dist'
+    }, {
+      console
+    })
+
+    logger.start()
+    logger.error(new Error('Test 1'))
+    logger.error(new Error('Test 2'))
+    logger.finish()
+
+    td.verify(console.error('Test 1'), { times: 1 })
+    td.verify(console.error('Test 2'), { times: 1 })
+    td.verify(console.log('Finished with 2 error(s)'))
+  })
+})

--- a/test/specs/loggers/dev-logger.spec.js
+++ b/test/specs/loggers/dev-logger.spec.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const td = require('testdouble')
+const color = require('../../../lib/color')
+const DevLogger = require('../../../lib/loggers/dev-logger')
+
+describe('Dev Logger', () => {
+  it('should log that dev server starts', () => {
+    const console = { log: td.function() }
+    const logger = new DevLogger({}, {
+      console
+    })
+
+    logger.startDevServer(8080)
+    td.verify(console.log('Houl dev server is running at http://localhost:8080'))
+  })
+
+  it('should log that a source file is updated', () => {
+    const console = { log: td.function() }
+    const logger = new DevLogger({
+      input: '/path/to/input'
+    }, {
+      console
+    })
+
+    logger.updateFile('/path/to/input/js/index.js')
+
+    td.verify(console.log(color.yellow('UPDATED') + ' /js/index.js'))
+  })
+
+  it('should log that there is a GET request', () => {
+    const console = { log: td.function() }
+    const logger = new DevLogger({}, {
+      console
+    })
+
+    logger.getFile('/js/index.js')
+
+    td.verify(console.log(color.green('GET') + ' /js/index.js'))
+  })
+})

--- a/test/specs/loggers/watch-logger.spec.js
+++ b/test/specs/loggers/watch-logger.spec.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const td = require('testdouble')
+const color = require('../../../lib/color')
+const WatchLogger = require('../../../lib/loggers/watch-logger')
+
+describe('Watch Logger', () => {
+  it('should log watching source directory', () => {
+    const console = { log: td.function() }
+    const logger = new WatchLogger({
+      base: '/path/to',
+      input: '/path/to/input'
+    }, {
+      console
+    })
+
+    logger.startWatching()
+    td.verify(console.log('Houl is watching the source directory: input/'))
+  })
+
+  it('should log that a source file was updated', () => {
+    const console = { log: td.function() }
+    const logger = new WatchLogger({
+      base: '/path/to',
+      input: '/path/to/input'
+    }, {
+      console
+    })
+
+    logger.updateFile('/path/to/input/index.html')
+    td.verify(console.log(color.yellow('UPDATED') + ' /input/index.html'))
+  })
+
+  it('should log the dest path of the build', () => {
+    const console = { log: td.function() }
+    const logger = new WatchLogger({
+      base: '/path/to',
+      output: '/path/to/output'
+    }, {
+      console
+    })
+
+    logger.writeFile('/path/to/output/index.html')
+    td.verify(console.log(color.cyan('WROTE') + ' /output/index.html'))
+  })
+})


### PR DESCRIPTION
This patch allows to print some logs while executing houl commands.
Note that this does not handle errors. It still print unhandled error event error. We may need to patch `.pipe` method and handle all error events in the user-created streams.