### PR TITLE
fix: filter updated files with `exclude` glob pattern

### DIFF
--- a/lib/cli/watch.js
+++ b/lib/cli/watch.js
@@ -65,7 +65,10 @@ exports.handler = (argv, debug) => {
       logger.updateFile(origin)
     }
 
-    stream(files)
+    const filtered = files.filter(f => !config.isExclude(f))
+    if (filtered.length === 0) return
+
+    stream(filtered)
       .on('data', file => {
         logger.writeFile(file.path)
       })

--- a/test/fixtures/e2e/houl.config.json
+++ b/test/fixtures/e2e/houl.config.json
@@ -1,7 +1,7 @@
 {
   "input": "src",
   "output": "dist",
-  "exclude": "**/_*/**",
+  "exclude": ["**/_*/**", "**/_*"],
   "taskFile": "./houl.task.js",
   "rules": {
     "js": {

--- a/test/fixtures/e2e/src/js/_excluded.js
+++ b/test/fixtures/e2e/src/js/_excluded.js
@@ -1,0 +1,1 @@
+console.log('This should always be excluded')

--- a/test/fixtures/e2e/updated-src/js/_excluded.js
+++ b/test/fixtures/e2e/updated-src/js/_excluded.js
@@ -1,0 +1,1 @@
+console.log('This should be excluded still')


### PR DESCRIPTION
The problem that this PR addresses is that the updated files are always built even if they matches `exclude` option glob pattern.
