### PR TITLE
fix(config): disallow overriding a config with `null` or `undefined`

### DIFF
--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -33,6 +33,7 @@ module.exports = class Config {
    * this config model and the provided argument
    */
   extend (config) {
+    config = util.filterProps(config, value => value != null)
     return new Config(Object.assign({}, this, config))
   }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -33,6 +33,16 @@ exports.mapValues = (val, fn) => {
   return res
 }
 
+exports.filterProps = (props, fn) => {
+  const res = {}
+  Object.keys(props).forEach(key => {
+    if (fn(props[key], key)) {
+      res[key] = props[key]
+    }
+  })
+  return res
+}
+
 exports.isLocalPath = pathname => {
   return /^[\.\/]/.test(pathname)
 }

--- a/test/specs/models/config.spec.js
+++ b/test/specs/models/config.spec.js
@@ -320,4 +320,42 @@ describe('Config model', () => {
 
     expect(c.proxy).toEqual([])
   })
+
+  it('extends itself with the provided object', () => {
+    const c = Config.create({
+      input: 'src',
+      output: 'dist'
+    }, {}, { base: '/' })
+
+    expect(c.input).toBe('/src')
+    expect(c.output).toBe('/dist')
+    expect(c.filter).toBe('**/*')
+    const e = c.extend({ filter: 'test/**/*' })
+    expect(e.input).toBe('/src')
+    expect(e.output).toBe('/dist')
+    expect(e.filter).toBe('test/**/*')
+  })
+
+  it('ignores null or undefined value for extend', () => {
+    const c = Config.create({
+      input: 'src',
+      output: 'dist'
+    }, {}, {
+      base: '/'
+    }).extend({
+      filter: 'test/**/*'
+    })
+
+    expect(c.input).toBe('/src')
+    expect(c.output).toBe('/dist')
+    expect(c.filter).toBe('test/**/*')
+    const e1 = c.extend({ filter: null })
+    expect(e1.input).toBe('/src')
+    expect(e1.output).toBe('/dist')
+    expect(e1.filter).toBe('test/**/*')
+    const e2 = c.extend({ filter: undefined })
+    expect(e2.input).toBe('/src')
+    expect(e2.output).toBe('/dist')
+    expect(e2.filter).toBe('test/**/*')
+  })
 })

--- a/test/specs/util.spec.js
+++ b/test/specs/util.spec.js
@@ -19,4 +19,20 @@ describe('Util', () => {
       expect(util.dropWhile([0, 0, 0], isZero)).toEqual([])
     })
   })
+
+  describe('filterProps', () => {
+    const isNotZero = item => item !== 0
+
+    it('filters object properties', () => {
+      const obj = {
+        foo: 0,
+        bar: 1,
+        baz: 'str'
+      }
+      expect(util.filterProps(obj, isNotZero)).toEqual({
+        bar: 1,
+        baz: 'str'
+      })
+    })
+  })
 })


### PR DESCRIPTION
This is related with #60.
If we specify `port` or `basePath` in config file, it should not be overwritten with undefined cli options. But the current behavior is like so.

This PR fix the behavior - if the cli options are not specified, it will not overwrite the options from a config file.