### PR TITLE
log show port number

### DIFF
--- a/lib/cli/dev.js
+++ b/lib/cli/dev.js
@@ -51,7 +51,7 @@ exports.handler = (argv, debug) => {
   }, resolver)
 
   bs.emitter.on('init', () => {
-    logger.startDevServer(argv.port, externalIp)
+    logger.startDevServer(config.port, externalIp)
   })
 
   const watcher = createWatcher(config, resolver, (name, files, origin) => {


### PR DESCRIPTION
The new version delete default port number.

So that the log will show:

```
Houl dev server is running at:
Local: http://localhost:undefined
External: http://192.168.188.177:undefined
```
Maybe add Integration Testing is a good choice for avoid the situation.

