### PR TITLE
feat: expose top level tasks as Node.js API

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,6 +1,7 @@
 const { PassThrough } = require('stream')
 const { build } = require('./build')
 const { dev: startDevServer } = require('./dev')
+const { watch } = require('./watch')
 
 function isDev () {
   return process.env.NODE_ENV !== 'production'
@@ -22,3 +23,4 @@ exports.dev = dev
 exports.prod = prod
 exports.build = build
 exports.startDevServer = startDevServer
+exports.watch = watch

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,5 +1,6 @@
 const { PassThrough } = require('stream')
 const { build } = require('./build')
+const { dev: startDevServer } = require('./dev')
 
 function isDev () {
   return process.env.NODE_ENV !== 'production'
@@ -20,3 +21,4 @@ function prod (stream) {
 exports.dev = dev
 exports.prod = prod
 exports.build = build
+exports.startDevServer = startDevServer

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,4 +1,5 @@
-const PassThrough = require('stream').PassThrough
+const { PassThrough } = require('stream')
+const { build } = require('./build')
 
 function isDev () {
   return process.env.NODE_ENV !== 'production'
@@ -8,10 +9,14 @@ function noop () {
   return new PassThrough({ objectMode: true })
 }
 
-exports.dev = function (stream) {
+function dev (stream) {
   return isDev() ? stream : noop()
 }
 
-exports.prod = function (stream) {
+function prod (stream) {
   return isDev() ? noop() : stream
 }
+
+exports.dev = dev
+exports.prod = prod
+exports.build = build

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,0 +1,94 @@
+const vfs = require('vinyl-fs')
+const hashSum = require('hash-sum')
+const loadConfig = require('./config').loadConfig
+const Cache = require('./cache')
+const DepResolver = require('./dep-resolver')
+const BuildLogger = require('./loggers/build-logger')
+const taskStream = require('./task-stream')
+const cacheStream = require('./cache-stream')
+const util = require('./util')
+
+/**
+ * The top level function to build sources.
+ * The 1st parameter can accept the following options:
+ *
+ * config - Path to a houl config file
+ * cache - Path to a houl cache file
+ * production - Enable production mode
+ * dot - Include dot files in output
+ * filter - Glob pattern for filtering input files
+ *
+ * The 2nd parameter is meant to be used for internal,
+ * so the users should not use it.
+ *
+ * The return value is a Promise object which will be
+ * resolved when the build is exit successfully.
+ */
+function build (options, debug = {}) {
+  if (options.production) {
+    process.env.NODE_ENV = 'production'
+  }
+
+  const config = loadConfig(options.config).extend({
+    filter: options.filter
+  })
+
+  // Logger
+  const logger = new BuildLogger(config, {
+    console: debug.console
+  })
+  logger.start()
+
+  // Process all files in input directory
+  let stream = vfs.src(config.vinylInput, { nodir: true, dot: options.dot })
+
+  if (options.cache) {
+    const cacheData = util.readFileSync(options.cache)
+
+    const cache = new Cache(hashSum)
+
+    const depResolver = DepResolver.create(config)
+
+    if (cacheData) {
+      const json = JSON.parse(cacheData)
+
+      // Restore cache data
+      cache.deserialize(json.cache)
+
+      // Restore deps data
+      depResolver.deserialize(json.deps)
+    }
+
+    stream = stream.pipe(cacheStream(cache, depResolver, util.readFileSync))
+
+    // Save cache
+    stream.on('end', () => {
+      const serialized = JSON.stringify({
+        cache: cache.serialize(),
+        deps: depResolver.serialize()
+      })
+      util.writeFileSync(options.cache, serialized)
+    })
+  }
+
+  return new Promise((resolve, reject) => {
+    // Transform inputs with rules
+    stream = stream.pipe(taskStream(config))
+      // This line does not work yet.
+      // We must patch .pipe method and handle
+      // all error events for each stream.
+      .on('error', err => {
+        logger.error(err)
+        reject(err)
+      })
+
+    // Output
+    return stream.pipe(vfs.dest(config.output))
+      .on('finish', () => {
+        logger.finish()
+        resolve()
+      })
+  })
+}
+
+exports.build = build

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const vfs = require('vinyl-fs')
 const hashSum = require('hash-sum')
 const loadConfig = require('./config').loadConfig

--- a/lib/cli/build.js
+++ b/lib/cli/build.js
@@ -1,15 +1,8 @@
 'use strict'
 
 const assert = require('assert')
-const vfs = require('vinyl-fs')
-const hashSum = require('hash-sum')
-const loadConfig = require('../config').loadConfig
 const findConfig = require('../config').findConfig
-const Cache = require('../cache')
-const DepResolver = require('../dep-resolver')
-const BuildLogger = require('../loggers/build-logger')
-const taskStream = require('../task-stream')
-const cacheStream = require('../cache-stream')
+const { build } = require('../build')
 const util = require('../util')
 
 exports.builder = {
@@ -33,65 +26,12 @@ exports.builder = {
   }
 }
 
-exports.handler = (argv, debug) => {
-  debug = debug || {}
-
-  if (argv.production) {
-    process.env.NODE_ENV = 'production'
-  }
-
+exports.handler = (argv, debug = {}) => {
   const configPath = argv.config || findConfig(process.cwd())
   assert(configPath, 'Config file is not found')
-  const config = loadConfig(configPath).extend({
-    filter: argv.filter
-  })
 
-  // Logger
-  const logger = new BuildLogger(config, {
+  const options = util.merge(argv, { config: configPath })
+  return build(options, {
     console: debug.console
   })
-  logger.start()
-
-  // Process all files in input directory
-  let stream = vfs.src(config.vinylInput, { nodir: true, dot: argv.dot })
-
-  if (argv.cache) {
-    const cacheData = util.readFileSync(argv.cache)
-
-    const cache = new Cache(hashSum)
-
-    const depResolver = DepResolver.create(config)
-
-    if (cacheData) {
-      const json = JSON.parse(cacheData)
-
-      // Restore cache data
-      cache.deserialize(json.cache)
-
-      // Restore deps data
-      depResolver.deserialize(json.deps)
-    }
-
-    stream = stream.pipe(cacheStream(cache, depResolver, util.readFileSync))
-
-    // Save cache
-    stream.on('end', () => {
-      const serialized = JSON.stringify({
-        cache: cache.serialize(),
-        deps: depResolver.serialize()
-      })
-      util.writeFileSync(argv.cache, serialized)
-    })
-  }
-
-  // Transform inputs with rules
-  stream = stream.pipe(taskStream(config))
-    // This line does not work yet.
-    // We must patch .pipe method and handle
-    // all error events for each stream.
-    .on('error', err => { logger.error(err) })
-
-  // Output
-  return stream.pipe(vfs.dest(config.output))
-    .on('finish', () => { logger.finish() })
 }

--- a/lib/cli/build.js
+++ b/lib/cli/build.js
@@ -31,7 +31,5 @@ exports.handler = (argv, debug = {}) => {
   assert(configPath, 'Config file is not found')
 
   const options = util.merge(argv, { config: configPath })
-  return build(options, {
-    console: debug.console
-  })
+  return build(options, debug)
 }

--- a/lib/cli/dev.js
+++ b/lib/cli/dev.js
@@ -1,14 +1,9 @@
 'use strict'
 
 const assert = require('assert')
-const url = require('url')
-const externalIp = require('../util').getIp()
-const loadConfig = require('../config').loadConfig
 const findConfig = require('../config').findConfig
-const DepResolver = require('../dep-resolver')
-const create = require('../externals/browser-sync')
-const createWatcher = require('../externals/watcher')
-const DevLogger = require('../loggers/dev-logger')
+const { dev } = require('../dev')
+const util = require('../util')
 
 exports.builder = {
   config: {
@@ -25,59 +20,11 @@ exports.builder = {
   }
 }
 
-exports.handler = (argv, debug) => {
-  debug = debug || {}
-
+exports.handler = (argv, debug = {}) => {
   const configPath = argv.config || findConfig(process.cwd())
   assert(configPath, 'Config file is not found')
   assert(!Number.isNaN(argv.port), '--port should be a number')
 
-  const config = loadConfig(configPath).extend({
-    port: argv.port,
-    basePath: argv['base-path']
-  })
-
-  // Logger
-  const logger = new DevLogger(config, {
-    console: debug.console
-  })
-
-  const resolver = DepResolver.create(config)
-
-  const bs = create(config, {
-    logLevel: 'silent',
-    middleware: logMiddleware,
-    open: !argv._debug // Internal
-  }, resolver)
-
-  bs.emitter.on('init', () => {
-    logger.startDevServer(argv.port, externalIp)
-  })
-
-  const watcher = createWatcher(config, resolver, (name, files, origin) => {
-    if (name === 'add') {
-      logger.addFile(origin)
-    } else if (name === 'change') {
-      logger.updateFile(origin)
-    }
-    bs.reload(files.map(resolveOutput))
-  })
-
-  return { bs, watcher }
-
-  function resolveOutput (inputName) {
-    const rule = config.findRuleByInput(inputName)
-
-    if (!rule) {
-      return inputName
-    } else {
-      return rule.getOutputPath(inputName)
-    }
-  }
-
-  function logMiddleware (req, res, next) {
-    const parsedPath = url.parse(req.url).pathname
-    logger.getFile(parsedPath)
-    next()
-  }
+  const options = util.merge(argv, { config: configPath })
+  return dev(options, debug)
 }

--- a/lib/cli/dev.js
+++ b/lib/cli/dev.js
@@ -25,6 +25,9 @@ exports.handler = (argv, debug = {}) => {
   assert(configPath, 'Config file is not found')
   assert(!Number.isNaN(argv.port), '--port should be a number')
 
-  const options = util.merge(argv, { config: configPath })
+  const options = util.merge(argv, {
+    config: configPath,
+    basePath: argv['base-path']
+  })
   return dev(options, debug)
 }

--- a/lib/cli/watch.js
+++ b/lib/cli/watch.js
@@ -1,16 +1,8 @@
 'use strict'
 
 const assert = require('assert')
-const vfs = require('vinyl-fs')
-const hashSum = require('hash-sum')
-const loadConfig = require('../config').loadConfig
 const findConfig = require('../config').findConfig
-const Cache = require('../cache')
-const DepResolver = require('../dep-resolver')
-const taskStream = require('../task-stream')
-const cacheStream = require('../cache-stream')
-const createWatcher = require('../externals/watcher')
-const WatchLogger = require('../loggers/watch-logger')
+const { watch } = require('../watch')
 const util = require('../util')
 
 exports.builder = {
@@ -28,68 +20,9 @@ exports.builder = {
 }
 
 exports.handler = (argv, debug) => {
-  debug = debug || { cb: util.noop }
-
   const configPath = argv.config || findConfig(process.cwd())
   assert(configPath, 'Config file is not found')
-  const config = loadConfig(configPath)
 
-  const cache = new Cache(hashSum)
-  const depResolver = DepResolver.create(config)
-
-  // Restore cache data
-  if (argv.cache) {
-    const cacheData = util.readFileSync(argv.cache)
-
-    if (cacheData) {
-      const json = JSON.parse(cacheData)
-
-      // Restore cache data
-      cache.deserialize(json.cache)
-
-      // Restore deps data
-      depResolver.deserialize(json.deps)
-    }
-  }
-
-  // Logger
-  const logger = new WatchLogger(config, {
-    console: debug.console || console
-  })
-
-  stream(config.vinylInput).on('finish', debug.cb)
-  return createWatcher(config, depResolver, (name, files, origin) => {
-    if (name === 'add') {
-      logger.addFile(origin)
-    } else if (name === 'change') {
-      logger.updateFile(origin)
-    }
-
-    const filtered = files.filter(f => !config.isExclude(f))
-    if (filtered.length === 0) return
-
-    stream(filtered)
-      .on('data', file => {
-        logger.writeFile(file.path)
-      })
-      .on('finish', debug.cb)
-  }).on('ready', () => {
-    logger.startWatching()
-  })
-
-  function stream(sources) {
-    return vfs.src(sources, { nodir: true, dot: argv.dot, base: config.input })
-      .pipe(cacheStream(cache, depResolver, util.readFileSync))
-      .pipe(taskStream(config))
-      .pipe(vfs.dest(config.output))
-      .on('finish', () => {
-        if (!argv.cache) return
-
-        const serialized = JSON.stringify({
-          cache: cache.serialize(),
-          deps: depResolver.serialize()
-        })
-        util.writeFileSync(argv.cache, serialized)
-      })
-  }
+  const options = util.merge(argv, { config: configPath })
+  return watch(options, debug)
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -42,7 +42,15 @@ function loadConfigFile (configPath) {
     path.basename(configPath) + ' is non-supported file format.'
   )
 
-  return require(path.resolve(configPath))
+  try {
+    return require(path.resolve(configPath))
+  } catch (e) {
+    if (e.code === 'MODULE_NOT_FOUND') {
+      throw new Error(`${configPath} is not found.`)
+    } else {
+      throw e
+    }
+  }
 }
 
 function resolvePresetPath (preset, base) {

--- a/lib/dev.js
+++ b/lib/dev.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const url = require('url')
+const externalIp = require('./util').getIp()
+const loadConfig = require('./config').loadConfig
+const DepResolver = require('./dep-resolver')
+const create = require('./externals/browser-sync')
+const createWatcher = require('./externals/watcher')
+const DevLogger = require('./loggers/dev-logger')
+
+/**
+ * The top level function for the dev server.
+ * The 1st parameter can accept the following options:
+ *
+ * config - Path to a houl config file
+ * port - Port number of dev server
+ * basePath - Base path of dev server
+ *
+ * The 2nd parameter and return value are meant to be used for internal,
+ * so the users should not use them.
+ */
+function dev (options, debug = {}) {
+  const config = loadConfig(options.config).extend({
+    port: options.port,
+    basePath: options['base-path']
+  })
+
+  // Logger
+  const logger = new DevLogger(config, {
+    console: debug.console
+  })
+
+  const resolver = DepResolver.create(config)
+
+  const bs = create(config, {
+    logLevel: 'silent',
+    middleware: logMiddleware,
+    open: !options._debug // Internal
+  }, resolver)
+
+  bs.emitter.on('init', () => {
+    logger.startDevServer(options.port, externalIp)
+  })
+
+  const watcher = createWatcher(config, resolver, (name, files, origin) => {
+    if (name === 'add') {
+      logger.addFile(origin)
+    } else if (name === 'change') {
+      logger.updateFile(origin)
+    }
+    bs.reload(files.map(resolveOutput))
+  })
+
+  return { bs, watcher }
+
+  function resolveOutput (inputName) {
+    const rule = config.findRuleByInput(inputName)
+
+    if (!rule) {
+      return inputName
+    } else {
+      return rule.getOutputPath(inputName)
+    }
+  }
+
+  function logMiddleware (req, res, next) {
+    const parsedPath = url.parse(req.url).pathname
+    logger.getFile(parsedPath)
+    next()
+  }
+}
+
+exports.dev = dev

--- a/lib/dev.js
+++ b/lib/dev.js
@@ -22,7 +22,7 @@ const DevLogger = require('./loggers/dev-logger')
 function dev (options, debug = {}) {
   const config = loadConfig(options.config).extend({
     port: options.port,
-    basePath: options['base-path']
+    basePath: options.basePath
   })
 
   // Logger

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -1,0 +1,93 @@
+'use strict'
+
+const vfs = require('vinyl-fs')
+const hashSum = require('hash-sum')
+const loadConfig = require('./config').loadConfig
+const Cache = require('./cache')
+const DepResolver = require('./dep-resolver')
+const taskStream = require('./task-stream')
+const cacheStream = require('./cache-stream')
+const createWatcher = require('./externals/watcher')
+const WatchLogger = require('./loggers/watch-logger')
+const util = require('./util')
+
+/**
+ * The top level function to start the watcher for incremental build.
+ * The 1st parameter can accept the following options:
+ *
+ * config - Path to a houl config file
+ * cache - Path to a houl cache file
+ * dot - Include dot files in output
+ *
+ * The 2nd parameter is meant to be used for internal,
+ * so the users should not use it.
+ *
+ * The return value is a chokidar watcher object
+ * which the user can use to execute any further processing.
+ */
+function watch (options, debug) {
+  debug = debug || { cb: util.noop }
+
+  const config = loadConfig(options.config)
+
+  const cache = new Cache(hashSum)
+  const depResolver = DepResolver.create(config)
+
+  // Restore cache data
+  if (options.cache) {
+    const cacheData = util.readFileSync(options.cache)
+
+    if (cacheData) {
+      const json = JSON.parse(cacheData)
+
+      // Restore cache data
+      cache.deserialize(json.cache)
+
+      // Restore deps data
+      depResolver.deserialize(json.deps)
+    }
+  }
+
+  // Logger
+  const logger = new WatchLogger(config, {
+    console: debug.console
+  })
+
+  stream(config.vinylInput).on('finish', debug.cb)
+  return createWatcher(config, depResolver, (name, files, origin) => {
+    if (name === 'add') {
+      logger.addFile(origin)
+    } else if (name === 'change') {
+      logger.updateFile(origin)
+    }
+
+    const filtered = files.filter(f => !config.isExclude(f))
+    if (filtered.length === 0) return
+
+    stream(filtered)
+      .on('data', file => {
+        logger.writeFile(file.path)
+      })
+      .on('finish', debug.cb)
+  }).on('ready', () => {
+    logger.startWatching()
+  })
+
+  function stream(sources) {
+    return vfs.src(sources, { nodir: true, dot: options.dot, base: config.input })
+      .pipe(cacheStream(cache, depResolver, util.readFileSync))
+      .pipe(taskStream(config))
+      .pipe(vfs.dest(config.output))
+      .on('finish', () => {
+        if (!options.cache) return
+
+        const serialized = JSON.stringify({
+          cache: cache.serialize(),
+          deps: depResolver.serialize()
+        })
+        util.writeFileSync(options.cache, serialized)
+      })
+  }
+}
+
+exports.watch = watch

--- a/test/e2e/build.spec.js
+++ b/test/e2e/build.spec.js
@@ -34,7 +34,7 @@ describe('Build CLI', () => {
   })
 
   it('should build in develop mode', done => {
-    build({ config }, { console }).on('finish', () => {
+    build({ config }, { console }).then(() => {
       compare('dev')
       done()
     })
@@ -44,17 +44,17 @@ describe('Build CLI', () => {
     build({
       config,
       production: true
-    }, { console }).on('finish', () => {
+    }, { console }).then(() => {
       compare('prod')
       done()
     })
   })
 
   it('should not build cached files', done => {
-    build({ config, cache }, { console }).on('finish', () => {
+    build({ config, cache }, { console }).then(() => {
       removeDist()
       revert = updateSrc()
-      build({ config, cache }, { console }).on('finish', () => {
+      build({ config, cache }, { console }).then(() => {
         compare('cache')
         done()
       })
@@ -62,21 +62,21 @@ describe('Build CLI', () => {
   })
 
   it('can output dot files', done => {
-    build({ config, dot: true }, { console }).on('finish', () => {
+    build({ config, dot: true }, { console }).then(() => {
       compare('dot')
       done()
     })
   })
 
   it('can filter input files', done => {
-    build({ config, filter: '**/*.scss' }, { console }).on('finish', () => {
+    build({ config, filter: '**/*.scss' }, { console }).then(() => {
       compare('filtered')
       done()
     })
   })
 
   it('outputs log', done => {
-    build({ config }, { console }).on('finish', () => {
+    build({ config }, { console }).then(() => {
       td.verify(console.error(), { times: 0, ignoreExtraArgs: true })
       td.verify(console.log('Building src -> dist'), { times: 1 })
       td.verify(console.log(

--- a/test/specs/config.spec.js
+++ b/test/specs/config.spec.js
@@ -23,6 +23,11 @@ describe('Config', () => {
       .toThrowError(/test\.coffee is non-supported file format/)
   })
 
+  it('throws if no config file is found', () => {
+    expect(() => read('not-exist.json'))
+      .toThrowError(/not-exist\.json is not found/)
+  })
+
   it('loads a function style config', () => {
     const config = read('preset-function.config.js')
     expect(config.rules.baz).not.toBe(undefined)


### PR DESCRIPTION
I've expose the top level tasks (`build`, `dev` and `watch`) as Node.js API. So the users can use them by importing corresponding function from `houl` package.

For example:

```js
const { build, startDevServer, watch } = require('houl')

const configPath = 'path/to/houl.config.json'

// same as `houl build`
build({ config: configPath }).then(() => {
  // called after build is finished
})

// same as `houl dev`
startDevServer({ config: configPath })

// same as `houl watch`
const watcher = watch({ config: configPath })
// the returned value of watch is a chokidar watcher object
watcher.on('change', file => {
  // do something
})
```

This is helpful when the users want to construct their own automation with houl.