### PR TITLE
chore(e2e): fix the problem that e2e test clashes sometimes

### DIFF
--- a/lib/externals/watcher.js
+++ b/lib/externals/watcher.js
@@ -4,10 +4,18 @@ const path = require('path')
 const chokidar = require('chokidar')
 
 module.exports = function createWatcher (config, depResolver, cb) {
-  return chokidar.watch(config.input, {
+  const options = {
     ignoreInitial: true,
     cwd: config.input
-  }).on('add', file => watchHandler('add', file))
+  }
+  if (process.env.TEST) {
+    // Disable fsevents on testing environment since it may cause clash sometimes.
+    // See: https://github.com/paulmillr/chokidar/issues/612
+    options.useFsEvents = false
+  }
+
+  return chokidar.watch(config.input, options)
+    .on('add', file => watchHandler('add', file))
     .on('change', file => watchHandler('change', file))
 
   function watchHandler(name, pathname) {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "dev": "chokidar \"lib/**/*.js\" \"test/specs/**/*.js\" -c \"npm run test:unit\" --silent --initial",
     "lint": "eslint bin lib test/specs test/e2e",
     "test": "npm run lint && npm run test:unit && npm run test:e2e",
-    "test:unit": "jasmine JASMINE_CONFIG_PATH=test/jasmine-unit.json",
-    "test:e2e": "node test/e2e/setup.js && jasmine JASMINE_CONFIG_PATH=test/jasmine-e2e.json",
+    "test:unit": "jasmine TEST=1 JASMINE_CONFIG_PATH=test/jasmine-unit.json",
+    "test:e2e": "node test/e2e/setup.js && jasmine TEST=1 JASMINE_CONFIG_PATH=test/jasmine-e2e.json",
     "release": "./release.sh"
   },
   "devDependencies": {


### PR DESCRIPTION
I'm still not sure why this causes but we can avoid by setting `useFsEvents = false` on chokidar according to https://github.com/paulmillr/chokidar/issues/612