### PR TITLE
feat: merge rules fields with preset

### DIFF
--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -135,7 +135,7 @@ function resolveExclude (exclude) {
 
 function resolveRules (rules, tasks, preset) {
   rules = util.mapValues(rules, (rule, key) => {
-    return new Rule(rule, key, tasks)
+    return Rule.create(rule, key, tasks, preset && preset.rules[key])
   })
 
   if (!preset) return rules

--- a/lib/models/rule.js
+++ b/lib/models/rule.js
@@ -29,14 +29,13 @@ const emptyRule = new class EmptyRule {
   }
 }
 
-module.exports = class Rule {
-  constructor (rule, inputExt, tasks) {
-    const taskName = this.taskName = typeof rule === 'string'
+class Rule {
+  constructor (rule, inputExt) {
+    this.taskName = typeof rule === 'string'
       ? rule
       : rule.task
 
-    assert(tasks[taskName], `Task "${taskName}" is not defined`)
-    this.task = createTask(tasks[taskName], rule.options || {})
+    this.task = null
 
     this.inputExt = inputExt
     this.outputExt = rule.outputExt || this.inputExt
@@ -68,7 +67,70 @@ module.exports = class Rule {
     }, false)
   }
 
+  merge (rule) {
+    const merged = new Rule({
+      task: rule.taskName || this.taskName,
+      outputExt: rule.outputExt || this.outputExt,
+      exclude: this.exclude.concat(rule.exclude),
+      progeny: mergeOptions(this.progeny, rule.progeny)
+    }, rule.inputExt)
+
+    // `task` may not loaded yet, so we need to check `taskName` instead.
+    merged.task = rule.taskName ? rule.task : this.task
+
+    return merged
+  }
+
+  static create (rawRule, inputExt, tasks, parent) {
+    let rule = new Rule(rawRule, inputExt)
+    if (parent) {
+      rule = parent.merge(rule)
+    }
+
+    if (!rule.task) {
+      assert(tasks[rule.taskName], `Task "${rule.taskName}" is not defined`)
+      rule.task = createTask(tasks[rule.taskName], rawRule.options || {})
+    }
+
+    return rule
+  }
+
   static get empty () {
     return emptyRule
   }
+}
+module.exports = Rule
+
+/**
+ * Assumes `a` and `b` is the same type
+ * but if either one is `null` or `undefined`, it will be just ignored.
+ */
+function mergeOptions (a, b) {
+  if (a == null) return b
+  if (b == null) return a
+
+  if (Array.isArray(a)) {
+    return a.concat(b)
+  }
+
+  if (
+    typeof a === 'object'
+    && !(a instanceof RegExp)
+  ) {
+    const res = {}
+    mergedKeys(a, b).forEach(key => {
+      res[key] = mergeOptions(a[key], b[key])
+    })
+    return res
+  }
+
+  return b
+}
+
+function mergedKeys (a, b) {
+  const keys = {}
+  Object.keys(a).concat(Object.keys(b)).forEach(key => {
+    keys[key] = true
+  })
+  return Object.keys(keys)
 }

--- a/test/specs/models/rule.spec.js
+++ b/test/specs/models/rule.spec.js
@@ -4,7 +4,7 @@ const Rule = require('../../../lib/models/rule')
 
 describe('Rule model', () => {
   it('has correct properties', () => {
-    const r = new Rule({
+    const r = Rule.create({
       task: 'foo',
       outputExt: 'css',
       exclude: '**/vendor/**',
@@ -28,7 +28,7 @@ describe('Rule model', () => {
   })
 
   it('accepts array formed exclude', () => {
-    const r = new Rule({
+    const r = Rule.create({
       task: 'foo',
       exclude: ['**/vendor/**', '**/.DS_Store']
     }, 'js', {
@@ -39,7 +39,7 @@ describe('Rule model', () => {
   })
 
   it('deals with string format', () => {
-    const r = new Rule('foo', 'js', {
+    const r = Rule.create('foo', 'js', {
       foo: () => 'foo'
     })
     expect(r.taskName).toBe('foo')
@@ -48,7 +48,7 @@ describe('Rule model', () => {
 
   it('asserts task is appear', () => {
     expect(() => {
-      new Rule({
+      Rule.create({
         task: 'foo'
       }, 'js', {
         bar: () => 'bar'
@@ -57,7 +57,7 @@ describe('Rule model', () => {
   })
 
   it('provides options to the task', () => {
-    const r = new Rule({
+    const r = Rule.create({
       task: 'foo',
       options: {
         test: 'success'
@@ -69,7 +69,7 @@ describe('Rule model', () => {
   })
 
   it('converts output path to input path', () => {
-    const r = new Rule({
+    const r = Rule.create({
       task: 'foo',
       outputExt: 'css'
     }, 'scss', {
@@ -80,7 +80,7 @@ describe('Rule model', () => {
   })
 
   it('converts input path to output path', () => {
-    const r = new Rule({
+    const r = Rule.create({
       task: 'foo',
       outputExt: 'css'
     }, 'scss', {
@@ -91,7 +91,7 @@ describe('Rule model', () => {
   })
 
   it('checks whether the given path is excluded or not', () => {
-    const r = new Rule({
+    const r = Rule.create({
       task: 'foo',
       exclude: ['**/vendor/**', '**/_*']
     }, 'js', {
@@ -101,6 +101,32 @@ describe('Rule model', () => {
     expect(r.isExclude('src/js/vendor/index.js')).toBe(true)
     expect(r.isExclude('src/js/_hidden.js')).toBe(true)
     expect(r.isExclude('src/js/index.js')).toBe(false)
+  })
+
+  it('throws a task not found', () => {
+    expect(() => {
+      Rule.create({
+        task: 'foo'
+      }, 'js', {
+        bar: () => 'bar'
+      })
+    }).toThrowError(/Task "foo" is not defined/)
+  })
+
+  it('throws a task in merged rule not found', () => {
+    const parent = Rule.create({
+      task: 'foo'
+    }, 'js', {
+      foo: () => 'foo'
+    })
+
+    expect(() => {
+      Rule.create({
+        task: 'foo'
+      }, 'js', {
+        bar: () => 'bar'
+      }, parent)
+    }).toThrowError(/Task "foo" is not defined/)
   })
 
   describe('Empty rule', () => {


### PR DESCRIPTION
BREAKING CHANGE: User defined rules no longer replace preset rule. It will be merged instead.

ref #71 

For the first step, I've changed the behavior of user defined `rules` field - it will be merged with preset's `rules` fields now.