### PR TITLE
feat: allow to modify raw preset config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -17,7 +17,7 @@ function loadConfig (configPath, configOptions, transform = util.identity) {
     ? configOrFn(configOptions || {})
     : configOrFn
 
-  // If it is a preset object, may be transformed via `preset.modify`
+  // If it is a preset object, may be transformed via `preset.modifyConfig`
   const config = transform(rawConfig) || rawConfig
 
   // Unify the `preset` option into the object style

--- a/lib/config.js
+++ b/lib/config.js
@@ -6,15 +6,19 @@ const fs = require('fs')
 const Config = require('./models/config')
 const util = require('./util')
 
-function loadConfig (configPath, configOptions) {
+function loadConfig (configPath, configOptions, transform = util.identity) {
   const options = {}
   const base = options.base = path.dirname(configPath)
 
-  const rawConfig = loadConfigFile(configPath)
+  const configOrFn = loadConfigFile(configPath)
+
   // Get a config object based on configOptions if it is a function
-  const config = typeof rawConfig === 'function'
-    ? rawConfig(configOptions || {})
-    : rawConfig
+  const rawConfig = typeof configOrFn === 'function'
+    ? configOrFn(configOptions || {})
+    : configOrFn
+
+  // If it is a preset object, may be transformed via `preset.modify`
+  const config = transform(rawConfig) || rawConfig
 
   // Unify the `preset` option into the object style
   const preset = typeof config.preset === 'string'
@@ -23,7 +27,7 @@ function loadConfig (configPath, configOptions) {
 
   if (preset && preset.name) {
     const presetPath = resolvePresetPath(preset.name, base)
-    options.preset = loadConfig(presetPath, preset.options)
+    options.preset = loadConfig(presetPath, preset.options, preset.modifyConfig)
   }
 
   const tasks = config.taskFile

--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -134,9 +134,13 @@ function resolveExclude (exclude) {
 }
 
 function resolveRules (rules, tasks, preset) {
-  rules = util.mapValues(rules, (rule, key) => {
-    return Rule.create(rule, key, tasks, preset && preset.rules[key])
-  })
+  rules = util.filterMapValues(
+    rules,
+    rule => rule != null,
+    (rule, key) => {
+      return Rule.create(rule, key, tasks, preset && preset.rules[key])
+    }
+  )
 
   if (!preset) return rules
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -25,13 +25,18 @@ exports.merge = (a, b) => {
   return res
 }
 
-exports.mapValues = (val, fn) => {
+function filterMapValues (val, filter, map) {
   const res = {}
   Object.keys(val).forEach(key => {
-    res[key] = fn(val[key], key)
+    if (filter(val[key], key)) {
+      res[key] = map(val[key], key)
+    }
   })
   return res
 }
+exports.filterMapValues = filterMapValues
+
+exports.mapValues = (val, fn) => filterMapValues(val, () => true, fn)
 
 exports.filterProps = (props, fn) => {
   const res = {}

--- a/test/fixtures/configs/normal-with-preset-modify.js
+++ b/test/fixtures/configs/normal-with-preset-modify.js
@@ -1,0 +1,10 @@
+module.exports = {
+  input: './src',
+  output: './dist',
+  preset: {
+    name: './preset.config.js',
+    modifyConfig: config => {
+      delete config.rules.js
+    }
+  }
+}

--- a/test/fixtures/configs/normal-with-preset-modify.js
+++ b/test/fixtures/configs/normal-with-preset-modify.js
@@ -2,9 +2,9 @@ module.exports = {
   input: './src',
   output: './dist',
   preset: {
-    name: './preset.config.js',
+    name: './preset-function.config.js',
     modifyConfig: config => {
-      delete config.rules.js
+      config.rules.baz = null
     }
   }
 }

--- a/test/specs/config.spec.js
+++ b/test/specs/config.spec.js
@@ -43,6 +43,11 @@ describe('Config', () => {
     expect(config.rules.baz.task()).toBe('bazOptions')
   })
 
+  it('modifies a preset object', () => {
+    const config = read('normal-with-preset-modify.js')
+    expect(config.rules.js).toBe(undefined)
+  })
+
   it('allows an empty taskFile field', () => {
     expect(() => {
       read('no-taskfile.js')

--- a/test/specs/config.spec.js
+++ b/test/specs/config.spec.js
@@ -45,7 +45,7 @@ describe('Config', () => {
 
   it('modifies a preset object', () => {
     const config = read('normal-with-preset-modify.js')
-    expect(config.rules.js).toBe(undefined)
+    expect(config.rules.baz).toBe(undefined)
   })
 
   it('allows an empty taskFile field', () => {


### PR DESCRIPTION
ref #71

We can modify a preset config object by specifying `modifyConfig` function in `preset` field.

```js
module.exports = {
  preset: {
    name: 'foo-preset',
    modifyConfig: config => {
      // remove js config
      delete config.rules.js
    }
  }
}
```

Also I made `rules` field can accept `null` or `undefined` value for the users can remove preset rules by just assigning such values.
